### PR TITLE
32 add placeholderapi internal expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ EzBoost is a modern, production-ready Minecraft plugin for Spigot, Paper, and Bu
 - **Boost token items**: Give, trade, or reward boost tokens. Players redeem tokens by right-clicking them to activate the corresponding boost.
 - **Live reload**: Reload all configuration and messages at runtime.
 - **MiniMessage support**: Rich formatting for all messages and GUI text.
+- **Internal message tags**: Boost-specific tags (`<boost_display>`, `<boost_cost>`, `<boost_duration>`, etc.) are available in `messages.yml` without PlaceholderAPI.
+- **PlaceholderAPI expansion**: Exposes 18+ placeholders covering boost status, active boost, cooldowns, time remaining, XP multiplier, and economy formatting for use in other plugins.
 
 ---
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -96,9 +96,10 @@ boost-replaced: "<yellow>Your active boost was replaced.</yellow>"
 boost-activated: "<green>Boost activated: <white><boost></white>.</green>"
 boost-expired: "<gray>Your boost <white><boost></white> has expired.</gray>"
 boost-cooldown: "<red>That boost is on cooldown for <white><time></white> seconds.</red>"
-insufficient-funds: "<red>You need <white><cost></white> to activate this boost.</red>"
+boost-effect-cooldown: "<red>The effect <white><effect></white> is on cooldown for <white><time></white> seconds.</red>"
+insufficient-funds: "<red>You need <white><cost_compact></white> to activate this boost.</red>"
 economy-unavailable: "<red>Economy is unavailable. Please contact an admin.</red>"
-cost-charged: "<gray>Charged <white><cost></white> for <white><boost></white>.</gray>"
+cost-charged: "<gray>Charged <white><cost_compact></white> for <white><boost></white>.</gray>"
 reload: "<green>EzBoost reloaded.</green>"
 only-players: "<red>Only players can use this command.</red>"
 invalid-target: "<red>Player not found.</red>"
@@ -110,7 +111,38 @@ actionbar:
   format: "<gray>Boost:</gray> <white><boost></white> <gray>(<time>s)</gray>"
 ```
 
-**Placeholders:** `<boost>`, `<time>`, `<cost>`, `<amount>`, `<player>`
+### Boost-context tags
+
+The following tags are automatically injected for messages that are sent in the context of a specific boost. No PlaceholderAPI is required for these.
+
+| Tag | Value | Available in |
+|-----|-------|-------------|
+| `<boost>` | Display name | All boost-context messages |
+| `<boost_display>` | Display name (explicit alias) | All boost-context messages |
+| `<boost_key>` | Internal config key | All boost-context messages |
+| `<boost_cost>` | Fully formatted cost (e.g. `50,000`) | All boost-context messages |
+| `<boost_cost_compact>` | Compact cost (e.g. `50K`) | All boost-context messages |
+| `<boost_cost_raw>` | Raw numeric cost (e.g. `50000`) | All boost-context messages |
+| `<boost_duration>` | Duration in seconds | All boost-context messages |
+| `<boost_cooldown>` | Cooldown in seconds | All boost-context messages |
+| `<cost>` | Alias for `<boost_cost>` (backward compat) | All boost-context messages |
+| `<cost_compact>` | Alias for `<boost_cost_compact>` (backward compat) | All boost-context messages |
+| `<time>` | Remaining cooldown in seconds | `boost-cooldown`, `boost-effect-cooldown` |
+| `<effect>` | Effect name | `boost-effect-cooldown` |
+
+**Boost-context messages** (those that receive boost tags automatically):
+`boost-activated`, `boost-expired`, `boost-cooldown`, `boost-effect-cooldown`, `insufficient-funds`, `cost-charged`, `token-used`
+
+Messages without boost context (`no-permission`, `boost-active`, `boost-replaced`, `boost-not-found`, etc.) do not have a single boost in scope and only support the generic tags listed in their own comments.
+
+**Other placeholders:**
+
+| Tag | Available in |
+|-----|-------------|
+| `<amount>` | `token-given` |
+| `<player>` | `token-given` |
+| `<boost>` (display name) | `actionbar.format` |
+| `<time>` (seconds remaining) | `actionbar.format` |
 
 ---
 

--- a/docs/integration/PlaceholderAPI.md
+++ b/docs/integration/PlaceholderAPI.md
@@ -10,51 +10,101 @@ This document describes the PlaceholderAPI expansion bundled with EzBoost and th
 
 ## Expansion identifier
 
-All placeholders use the `ezboost` expansion identifier. In PAPI syntax wrap the identifier in percent signs, for example `%ezboost_price_formatted_50000%`.
+All placeholders use the `ezboost` expansion identifier. Wrap the identifier in percent signs in PAPI syntax, for example `%ezboost_price_formatted_50000%`.
+
+---
 
 ## Available placeholders
 
-The expansion supports parameterized placeholders. Replace `<arg>` with either a numeric amount or a boost key, depending on the placeholder.
+### Price & currency
 
-- `ezboost_price_formatted_<amount|boostkey>` — Formats a numeric amount or the configured cost of `<boostkey>` using EzBoost's number-format settings (grouping, separators, decimals). Examples:
-	- `%ezboost_price_formatted_50000%` → `50,000` (or `50.000` depending on config)
-	- `%ezboost_price_formatted_superboost%` → formatted cost of boost `superboost` for the requesting player
-- `ezboost_price_raw_<boostkey>` — Raw numeric cost for `<boostkey>` (no formatting). Example: `%ezboost_price_raw_superboost%` → `50000`
- - `ezboost_price_raw_<boostkey>` — Raw numeric cost for `<boostkey>` (no formatting). Example: `%ezboost_price_raw_superboost%` → `50000`
-- `ezboost_boost_display_<boostkey>` — Display name for boost (from `boosts.yml`).
-- `ezboost_boost_cost_<boostkey>` — Formatted cost for `<boostkey>` (convenience wrapper for `price_formatted`).
-- `ezboost_boost_duration_<boostkey>` — Duration in seconds for `<boostkey>`.
-- `ezboost_boost_status_<boostkey>` — Status for the requesting player: one of `available`, `locked`, `active`, `insufficient`, `cooldown`.
-- `ezboost_player_can_afford_<boostkey>` — `true`/`false` whether the requesting player can afford the boost.
-- `ezboost_currency_symbol` — Returns the configured currency label from `economy.yml` (if set), otherwise empty string.
- - `ezboost_price_compact_<amount|boostkey>` — Compact formatted amount using K/M suffixes (e.g. `50K`, `1.2M`). Examples:
-	 - `%ezboost_price_compact_50000%` → `50K`
-	 - `%ezboost_price_compact_superboost%` → compact cost for `superboost`
+| Placeholder | Returns |
+|-------------|---------|
+| `%ezboost_price_formatted_<amount\|boostkey>%` | Formatted number or the cost of `<boostkey>` (grouping, separators, decimals from config). Example: `50,000` |
+| `%ezboost_price_compact_<amount\|boostkey>%` | Compact cost using K/M suffixes. Example: `50K`, `1.2M` |
+| `%ezboost_price_raw_<boostkey>%` | Raw numeric cost with no formatting. Example: `50000` |
+| `%ezboost_currency_symbol%` | Configured currency label from `economy.yml`, or empty |
+
+### Boost info (requires player context for world/region overrides)
+
+| Placeholder | Returns |
+|-------------|---------|
+| `%ezboost_boost_display_<boostkey>%` | Display name of `<boostkey>` |
+| `%ezboost_boost_cost_<boostkey>%` | Formatted cost of `<boostkey>` (same as `price_formatted`) |
+| `%ezboost_boost_duration_<boostkey>%` | Duration in seconds |
+| `%ezboost_boost_status_<boostkey>%` | Player's status: `available`, `locked`, `active`, `insufficient`, or `cooldown` |
+| `%ezboost_player_can_afford_<boostkey>%` | `true` / `false` — whether the requesting player can afford the boost |
+
+### Active boost state
+
+| Placeholder | Returns |
+|-------------|---------|
+| `%ezboost_has_active_boost%` | `true` / `false` — whether the player has a running boost |
+| `%ezboost_active_boost%` | Config key of the active boost, or empty |
+| `%ezboost_active_boost_display%` | Display name of the active boost, or empty |
+| `%ezboost_active_boost_time_remaining%` | Seconds remaining as a plain integer |
+| `%ezboost_active_boost_time_remaining_formatted%` | `MM:SS` (under 1 hour) or `HH:MM:SS` (1 hour or more) |
+| `%ezboost_is_active_<boostkey>%` | `true` / `false` — plain boolean, no permission or cost check |
+
+### Cooldowns
+
+| Placeholder | Returns |
+|-------------|---------|
+| `%ezboost_cooldown_remaining_<boostkey>%` | Remaining cooldown in seconds as a plain integer, `0` if not on cooldown |
+| `%ezboost_cooldown_remaining_formatted_<boostkey>%` | `MM:SS` or `HH:MM:SS`, `00:00` if not on cooldown |
+
+### XP
+
+| Placeholder | Returns |
+|-------------|---------|
+| `%ezboost_xp_multiplier%` | Active XP multiplier as an integer (e.g. `2`). Returns `1` if no XP boost is running |
+
+---
 
 ## Formatting behaviour
 
-- Number formatting honours `economy.format.*` settings from `economy.yml`:
-	- `grouping` (true/false)
-	- `grouping-separator` (single character, default `,`)
-	- `decimal-separator` (single character, default `.`)
-	- `decimal-places` (integer, default `2`)
-- If a configured boost cost is an integer (e.g. `50_000.0`), the expansion will omit decimals by default; non-integer amounts use `decimal-places`.
+Number formatting honours `economy.format.*` settings from `economy.yml`:
+- `grouping` — `true`/`false`, enable thousands grouping
+- `grouping-separator` — single character, default `,`
+- `decimal-separator` — single character, default `.`
+- `decimal-places` — integer, default `2`
+
+Compact formatting (`price_compact`) uses K / M suffixes and ignores the decimal-places setting.
+
+---
 
 ## Examples
 
-- In another plugin's message or scoreboard: `Needed: %ezboost_price_formatted_superboost%`
-- On a sign via PAPI-supporting sign plugin: line: `Cost: %ezboost_price_formatted_superboost%`
+**Scoreboard line showing active boost and time:**
+```
+Boost: %ezboost_active_boost_display% (%ezboost_active_boost_time_remaining_formatted%)
+```
+
+**Conditional button (e.g. in a GUI plugin) — only visible when no boost is active:**
+```
+condition: %ezboost_has_active_boost% == false
+```
+
+**Shop sign showing cost:**
+```
+Cost: %ezboost_price_formatted_speed%
+```
+
+**XP rate display:**
+```
+XP rate: %ezboost_xp_multiplier%x
+```
+
+**Cooldown display for a specific boost:**
+```
+Cooldown: %ezboost_cooldown_remaining_formatted_speed%
+```
+
+---
 
 ## Notes & fallbacks
 
-- The expansion resolves boost keys using the requesting player's world/region context — a boost key might return a different cost depending on overrides.
-- If a boost key cannot be resolved or an argument is invalid, the placeholder returns an empty string.
+- All boost key lookups use the requesting player's world/region context, so results may differ depending on active overrides.
+- If a boost key cannot be resolved or an argument is invalid, the placeholder returns an empty string (`""`), `false`, or `0` depending on the placeholder type.
 - The expansion registers at plugin startup when PlaceholderAPI is present; no manual registration is required.
-
-## Future ideas
-
-- Add compact formatting (`50K`, `1.2M`) as `%ezboost_price_compact_<arg>%`.
-- Add localization-aware formatting based on server locale.
-
-If you'd like, I can add the compact-format placeholder and a short example section in `docs/` showing common PAPI use-cases.
 

--- a/docs/topics/bbcode.txt
+++ b/docs/topics/bbcode.txt
@@ -33,6 +33,8 @@
 [*][B]Vault economy support[/B] – Optionally charge players for activating boosts.
 [*][B]Live reload[/B] – Reload all configuration and messages at runtime with [icode]/ezboost reload[/icode].
 [*][B]Friendly messaging[/B] – Customizable MiniMessage strings for actionbar/status feedback.
+[*][B]Internal message tags[/B] – Use [icode]<boost_display>[/icode], [icode]<boost_cost>[/icode], [icode]<boost_duration>[/icode] and more directly in [icode]messages.yml[/icode] — no PlaceholderAPI needed.
+[*][B]PlaceholderAPI expansion[/B] – 18+ placeholders for boost status, active boost, cooldowns, time remaining, XP multiplier and economy formatting. Usable in scoreboards, GUI plugins and any PAPI-compatible plugin.
 [*][B]Command hooks[/B] – Run console commands on enable/disable/toggle per boost.
 [*][B]Player-friendly behavior[/B] – Reapply boosts on join, keep on death, and refund on failed activation.
 [/LIST]

--- a/docs/topics/markdown.md
+++ b/docs/topics/markdown.md
@@ -41,6 +41,8 @@ For issues, feature requests, and the latest releases, always check GitHub first
 - **Boost token items**: Give, trade, or reward boost tokens with `/ezboost give`. Players redeem tokens by right-clicking them to activate the boost.
 - **Live reload**: Reload all configuration and messages at runtime with `/ezboost reload`.
 - **MiniMessage support**: Rich formatting for all messages and GUI text.
+- **Internal message tags**: Boost-specific tags (`<boost_display>`, `<boost_cost>`, `<boost_duration>`, etc.) are available directly in `messages.yml` — no PlaceholderAPI required.
+- **PlaceholderAPI expansion**: 18+ placeholders covering boost status, active boost, cooldowns, time remaining, XP multiplier, and economy formatting, usable in scoreboards, GUI plugins, and any PAPI-compatible plugin. See the [PlaceholderAPI integration guide](https://github.com/ez-plugins/EzBoost/blob/main/docs/integration/PlaceholderAPI.md).
 - **Command hooks**: Run console commands on enable/disable/toggle per boost.
 - **Player-friendly behavior**: Reapply boosts on join, keep on death, and refund on failed activation.
 

--- a/src/main/java/com/skyblockexp/ezboost/boost/BoostManager.java
+++ b/src/main/java/com/skyblockexp/ezboost/boost/BoostManager.java
@@ -206,6 +206,24 @@ public final class BoostManager {
         return state != null && boostKey.equalsIgnoreCase(state.activeBoostKey()) && state.endTimestamp() > System.currentTimeMillis();
     }
 
+    /**
+     * Returns the active boost key for the player, or {@code null} if no boost is currently active.
+     */
+    public String getActiveBoostKey(Player player) {
+        BoostState state = states.get(player.getUniqueId());
+        if (state == null || state.activeBoostKey() == null) return null;
+        return state.endTimestamp() > System.currentTimeMillis() ? state.activeBoostKey() : null;
+    }
+
+    /**
+     * Returns the remaining duration of the player's active boost in seconds, or {@code 0} if none.
+     */
+    public long getActiveBoostTimeRemaining(Player player) {
+        BoostState state = states.get(player.getUniqueId());
+        if (state == null || state.activeBoostKey() == null) return 0L;
+        return Math.max(0L, (state.endTimestamp() - System.currentTimeMillis()) / 1000L);
+    }
+
     public long getCooldownRemaining(Player player, String boostKey) {
         BoostState state = states.get(player.getUniqueId());
         if (state == null) {
@@ -308,11 +326,14 @@ public final class BoostManager {
                         }
                         try {
                             player.sendMessage(messages.message("boost-effect-cooldown",
+                                    BoostTagResolvers.forBoost(effective, currencyFormatter),
                                     Placeholder.parsed("time", String.valueOf(remaining)),
                                     Placeholder.parsed("effect", effectName)));
                         } catch (Exception ex) {
                             // Fallback to generic message if key missing
-                            player.sendMessage(messages.message("boost-cooldown", Placeholder.parsed("time", String.valueOf(remaining))));
+                            player.sendMessage(messages.message("boost-cooldown",
+                                    BoostTagResolvers.forBoost(effective, currencyFormatter),
+                                    Placeholder.parsed("time", String.valueOf(remaining))));
                         }
                         return false;
                     }
@@ -321,14 +342,18 @@ public final class BoostManager {
                 long cooldownEnd = state.cooldownEnd(cooldownKey(effective.key()));
                 if (cooldownEnd > now) {
                     long remaining = Math.max(0L, (cooldownEnd - now) / 1000L);
-                    player.sendMessage(messages.message("boost-cooldown", Placeholder.parsed("time", String.valueOf(remaining))));
+                    player.sendMessage(messages.message("boost-cooldown",
+                            BoostTagResolvers.forBoost(effective, currencyFormatter),
+                            Placeholder.parsed("time", String.valueOf(remaining))));
                     return false;
                 }
             } else {
                 long cooldownEnd = state.cooldownEnd(cooldownKey(effective.key()));
                 if (cooldownEnd > now) {
                     long remaining = Math.max(0L, (cooldownEnd - now) / 1000L);
-                    player.sendMessage(messages.message("boost-cooldown", Placeholder.parsed("time", String.valueOf(remaining))));
+                    player.sendMessage(messages.message("boost-cooldown",
+                            BoostTagResolvers.forBoost(effective, currencyFormatter),
+                            Placeholder.parsed("time", String.valueOf(remaining))));
                     return false;
                 }
             }
@@ -345,8 +370,7 @@ public final class BoostManager {
             EconomyResponse response = economyService.withdraw(player, cost);
             if (!response.transactionSuccess()) {
                 player.sendMessage(messages.message("insufficient-funds",
-                    Placeholder.parsed("cost", currencyFormatter.format(cost)),
-                    Placeholder.parsed("cost_compact", currencyFormatter.formatCompact(cost))));
+                    BoostTagResolvers.forBoost(effective, currencyFormatter)));
                 return false;
             }
             charged = true;
@@ -393,14 +417,12 @@ public final class BoostManager {
         scheduleExpiry(player, effective, endTimestamp);
         scheduleActionbar(player, effective);
         runEnableCommands(player, effective);
-        player.sendMessage(messages.message("boost-activated", Placeholder.parsed("boost", effective.displayName())));
-    if (charged) {
-        player.sendMessage(messages.message("cost-charged", Placeholder.parsed("boost", effective.key()),
-            Placeholder.parsed("cost", currencyFormatter.format(cost)),
-            Placeholder.parsed("cost_compact", currencyFormatter.formatCompact(cost))));
-    }
+        player.sendMessage(messages.message("boost-activated", BoostTagResolvers.forBoost(effective, currencyFormatter)));
+        if (charged) {
+            player.sendMessage(messages.message("cost-charged", BoostTagResolvers.forBoost(effective, currencyFormatter)));
+        }
         if (source == ActivationSource.TOKEN) {
-            player.sendMessage(messages.message("token-used", Placeholder.parsed("boost", effective.key())));
+            player.sendMessage(messages.message("token-used", BoostTagResolvers.forBoost(effective, currencyFormatter)));
         }
         saveStates();
         return true;
@@ -515,7 +537,7 @@ public final class BoostManager {
                 }
                 runDisableCommands(player, boost);
                 if (!silent && config.settings().sendExpiredMessage()) {
-                    player.sendMessage(messages.message("boost-expired", Placeholder.parsed("boost", activeKey)));
+                    player.sendMessage(messages.message("boost-expired", BoostTagResolvers.forBoost(boost, currencyFormatter)));
                 }
             }
         }

--- a/src/main/java/com/skyblockexp/ezboost/boost/BoostTagResolvers.java
+++ b/src/main/java/com/skyblockexp/ezboost/boost/BoostTagResolvers.java
@@ -1,0 +1,58 @@
+package com.skyblockexp.ezboost.boost;
+
+import com.skyblockexp.ezboost.economy.CurrencyFormatter;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+
+/**
+ * Builds a MiniMessage {@link TagResolver} that exposes common boost-definition tags
+ * for use in EzBoost messages — no PlaceholderAPI required.
+ *
+ * <p>Available tags (usable in any message that receives this resolver):
+ * <ul>
+ *   <li>{@code <boost>}            — display name (backward-compat alias for {@code <boost_display>})</li>
+ *   <li>{@code <boost_display>}    — display name</li>
+ *   <li>{@code <boost_key>}        — internal config key</li>
+ *   <li>{@code <boost_cost>}       — fully formatted cost (e.g. {@code 50,000})</li>
+ *   <li>{@code <boost_cost_compact>} — compact cost (e.g. {@code 50K})</li>
+ *   <li>{@code <boost_cost_raw>}   — raw numeric cost (no formatting, no label)</li>
+ *   <li>{@code <boost_duration>}   — duration in seconds</li>
+ *   <li>{@code <boost_cooldown>}   — cooldown in seconds</li>
+ *   <li>{@code <cost>}             — alias for {@code <boost_cost>} (backward compat)</li>
+ *   <li>{@code <cost_compact>}     — alias for {@code <boost_cost_compact>} (backward compat)</li>
+ * </ul>
+ */
+public final class BoostTagResolvers {
+
+    private BoostTagResolvers() {}
+
+    /**
+     * Creates a {@link TagResolver} with all boost-definition tags populated from {@code boost}.
+     *
+     * @param boost     the boost definition to expose
+     * @param formatter the currency formatter used to format cost values
+     * @return a resolver ready to pass to {@code Messages#message()} or any MiniMessage call
+     */
+    public static TagResolver forBoost(BoostDefinition boost, CurrencyFormatter formatter) {
+        double cost = boost.cost();
+        String costFormatted = formatter.format(cost);
+        String costCompact = formatter.formatCompact(cost);
+        String costRaw = (cost == Math.floor(cost) && !Double.isInfinite(cost))
+                ? String.valueOf((long) cost)
+                : String.valueOf(cost);
+
+        return TagResolver.resolver(
+                Placeholder.parsed("boost", boost.displayName()),
+                Placeholder.parsed("boost_display", boost.displayName()),
+                Placeholder.parsed("boost_key", boost.key()),
+                Placeholder.parsed("boost_cost", costFormatted),
+                Placeholder.parsed("boost_cost_compact", costCompact),
+                Placeholder.parsed("boost_cost_raw", costRaw),
+                Placeholder.parsed("boost_duration", String.valueOf(boost.durationSeconds())),
+                Placeholder.parsed("boost_cooldown", String.valueOf(boost.cooldownSeconds())),
+                // backward-compat aliases kept so existing messages.yml values keep working
+                Placeholder.parsed("cost", costFormatted),
+                Placeholder.parsed("cost_compact", costCompact)
+        );
+    }
+}

--- a/src/main/java/com/skyblockexp/ezboost/placeholder/EzBoostPlaceholder.java
+++ b/src/main/java/com/skyblockexp/ezboost/placeholder/EzBoostPlaceholder.java
@@ -1,8 +1,10 @@
 package com.skyblockexp.ezboost.placeholder;
 
 import com.skyblockexp.ezboost.EzBoostPlugin;
+import com.skyblockexp.ezboost.api.EzBoostAPI;
 import com.skyblockexp.ezboost.boost.BoostDefinition;
 import com.skyblockexp.ezboost.boost.BoostManager;
+import com.skyblockexp.ezboost.boost.XpBoostEffect;
 import java.util.Optional;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.entity.Player;
@@ -169,6 +171,78 @@ public class EzBoostPlaceholder extends PlaceholderExpansion {
             return label == null ? "" : label;
         }
 
+        // has_active_boost — true/false whether the player has a running boost
+        if (identifier.equals("has_active_boost")) {
+            if (player == null) return "false";
+            return String.valueOf(boostManager.getActiveBoostKey(player) != null);
+        }
+
+        // active_boost — key of the player's current boost, or empty
+        if (identifier.equals("active_boost")) {
+            if (player == null) return "";
+            String key = boostManager.getActiveBoostKey(player);
+            return key != null ? key : "";
+        }
+
+        // active_boost_display — display name of the current boost, or empty
+        if (identifier.equals("active_boost_display")) {
+            if (player == null) return "";
+            String key = boostManager.getActiveBoostKey(player);
+            if (key == null) return "";
+            return boostManager.getBoost(key, player).map(BoostDefinition::displayName).orElse("");
+        }
+
+        // active_boost_time_remaining_formatted — MM:SS / HH:MM:SS, checked before raw
+        if (identifier.equals("active_boost_time_remaining_formatted")) {
+            if (player == null) return formatSeconds(0L);
+            return formatSeconds(boostManager.getActiveBoostTimeRemaining(player));
+        }
+
+        // active_boost_time_remaining — seconds as integer string
+        if (identifier.equals("active_boost_time_remaining")) {
+            if (player == null) return "0";
+            return String.valueOf(boostManager.getActiveBoostTimeRemaining(player));
+        }
+
+        // is_active_<boostkey> — plain boolean, no permission/cost logic
+        if (identifier.startsWith("is_active_")) {
+            if (player == null) return "false";
+            String key = identifier.substring("is_active_".length());
+            return String.valueOf(boostManager.isActive(player, key));
+        }
+
+        // cooldown_remaining_formatted_<boostkey> — checked before raw variant
+        if (identifier.startsWith("cooldown_remaining_formatted_")) {
+            if (player == null) return formatSeconds(0L);
+            String key = identifier.substring("cooldown_remaining_formatted_".length());
+            return formatSeconds(boostManager.getCooldownRemaining(player, key));
+        }
+
+        // cooldown_remaining_<boostkey> — seconds as integer string
+        if (identifier.startsWith("cooldown_remaining_")) {
+            if (player == null) return "0";
+            String key = identifier.substring("cooldown_remaining_".length());
+            return String.valueOf(boostManager.getCooldownRemaining(player, key));
+        }
+
+        // xp_multiplier — active XP multiplier for the player (1 if no xpboost active)
+        if (identifier.equals("xp_multiplier")) {
+            if (player == null) return "1";
+            Object effect = EzBoostAPI.getCustomBoostEffects().get("xpboost");
+            if (effect instanceof XpBoostEffect xpEffect) {
+                return String.valueOf(xpEffect.getMultiplier(player));
+            }
+            return "1";
+        }
+
         return "";
+    }
+
+    private static String formatSeconds(long seconds) {
+        if (seconds >= 3600) {
+            return String.format("%02d:%02d:%02d",
+                    seconds / 3600, (seconds % 3600) / 60, seconds % 60);
+        }
+        return String.format("%02d:%02d", seconds / 60, seconds % 60);
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -4,13 +4,25 @@
 # Customize all plugin messages and prefixes here.
 # Supports MiniMessage formatting (see https://docs.advntr.dev/minimessage/ for syntax).
 #
-# Placeholders:
-#   <boost>   - Name of the boost
-#   <time>    - Time remaining (seconds)
-#   <cost>    - Cost of the boost (full formatted)
-#   <cost_compact> - Compact cost (e.g. 50K, 1.2M)
-#   <amount>  - Amount of tokens
-#   <player>  - Player name
+# Common placeholders (available in all messages where noted):
+#   <boost>            - Boost display name  (boost-activated, boost-expired, boost-cooldown,
+#                        boost-effect-cooldown, cost-charged, token-used, insufficient-funds)
+#   <boost_display>    - Boost display name (same as <boost>)
+#   <boost_key>        - Internal boost key (config section name)
+#   <boost_cost>       - Fully formatted cost (e.g. 50,000)
+#   <boost_cost_compact> - Compact cost (e.g. 50K, 1.2M)
+#   <boost_cost_raw>   - Raw numeric cost without formatting
+#   <boost_duration>   - Duration in seconds
+#   <boost_cooldown>   - Cooldown in seconds
+#   <cost>             - Alias for <boost_cost> (backward compat)
+#   <cost_compact>     - Alias for <boost_cost_compact> (backward compat)
+#   <time>             - Time remaining in seconds (boost-cooldown, boost-effect-cooldown)
+#   <effect>           - Effect name (boost-effect-cooldown only)
+#   <amount>           - Amount of tokens (token-given)
+#   <player>           - Player name (token-given)
+#
+# Boost-context tags (<boost>, <boost_*>, <cost>, <cost_compact>) are injected automatically
+# for messages that are sent in the context of a specific boost — no PlaceholderAPI needed.
 #
 # Section:
 #   actionbar:

--- a/src/test/java/com/skyblockexp/ezboost/boost/BoostTagResolversTest.java
+++ b/src/test/java/com/skyblockexp/ezboost/boost/BoostTagResolversTest.java
@@ -1,0 +1,81 @@
+package com.skyblockexp.ezboost.boost;
+
+import com.skyblockexp.ezboost.economy.CurrencyFormatter;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BoostTagResolversTest {
+
+    private static final MiniMessage MM = MiniMessage.miniMessage();
+    private static final LegacyComponentSerializer LEGACY = LegacyComponentSerializer.builder()
+            .hexColors()
+            .useUnusualXRepeatedCharacterHexFormat()
+            .build();
+
+    private static String resolve(String template, TagResolver resolver) {
+        return LEGACY.serialize(MM.deserialize(template, resolver));
+    }
+
+    private static BoostDefinition boost(double cost) {
+        return new BoostDefinition(
+                "superboost", "Super Boost", Material.DIAMOND,
+                List.of(new BoostEffect(null, 0, null)),
+                new BoostCommands(List.of(), List.of(), List.of()),
+                120, 60, cost, null, true);
+    }
+
+    @Test
+    public void allTagsResolveCorrectly() {
+        TagResolver resolver = BoostTagResolvers.forBoost(boost(50000.0), new CurrencyFormatter(null));
+
+        assertEquals("Super Boost", resolve("<boost>", resolver));
+        assertEquals("Super Boost", resolve("<boost_display>", resolver));
+        assertEquals("superboost", resolve("<boost_key>", resolver));
+        assertEquals("50,000", resolve("<boost_cost>", resolver));
+        assertEquals("50K", resolve("<boost_cost_compact>", resolver));
+        assertEquals("50000", resolve("<boost_cost_raw>", resolver));
+        assertEquals("120", resolve("<boost_duration>", resolver));
+        assertEquals("60", resolve("<boost_cooldown>", resolver));
+    }
+
+    @Test
+    public void backwardCompatAliasesMatchBoostVariants() {
+        TagResolver resolver = BoostTagResolvers.forBoost(boost(1200.0), new CurrencyFormatter(null));
+
+        assertEquals(resolve("<boost_cost>", resolver), resolve("<cost>", resolver));
+        assertEquals(resolve("<boost_cost_compact>", resolver), resolve("<cost_compact>", resolver));
+    }
+
+    @Test
+    public void rawCostOmitsDecimalForWholeNumbers() {
+        TagResolver resolver = BoostTagResolvers.forBoost(boost(500.0), new CurrencyFormatter(null));
+        assertEquals("500", resolve("<boost_cost_raw>", resolver));
+    }
+
+    @Test
+    public void rawCostKeepsDecimalForFractionalValues() {
+        BoostDefinition def = new BoostDefinition(
+                "k", "K", Material.DIAMOND,
+                List.of(new BoostEffect(null, 0, null)),
+                new BoostCommands(List.of(), List.of(), List.of()),
+                60, 0, 1.5, null, true);
+        TagResolver resolver = BoostTagResolvers.forBoost(def, new CurrencyFormatter(null));
+        assertEquals("1.5", resolve("<boost_cost_raw>", resolver));
+    }
+
+    @Test
+    public void zeroOrFreeCostFormatsAsFree() {
+        TagResolver resolver = BoostTagResolvers.forBoost(boost(0.0), new CurrencyFormatter(null));
+        // CurrencyFormatter returns "Free" for non-positive amounts
+        assertEquals("Free", resolve("<boost_cost>", resolver));
+        assertEquals("Free", resolve("<cost>", resolver));
+        assertEquals("0", resolve("<boost_cost_raw>", resolver));
+    }
+}

--- a/src/test/java/com/skyblockexp/ezboost/placeholder/EzBoostPlaceholderTest.java
+++ b/src/test/java/com/skyblockexp/ezboost/placeholder/EzBoostPlaceholderTest.java
@@ -1,18 +1,24 @@
 package com.skyblockexp.ezboost.placeholder;
 
 import com.skyblockexp.ezboost.EzBoostPlugin;
+import com.skyblockexp.ezboost.api.EzBoostAPI;
 import com.skyblockexp.ezboost.boost.BoostDefinition;
 import com.skyblockexp.ezboost.boost.BoostManager;
 import com.skyblockexp.ezboost.boost.BoostCommands;
 import com.skyblockexp.ezboost.boost.BoostEffect;
+import com.skyblockexp.ezboost.boost.CustomBoostEffect;
+import com.skyblockexp.ezboost.boost.XpBoostEffect;
 import com.skyblockexp.ezboost.economy.CurrencyFormatter;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -73,5 +79,177 @@ public class EzBoostPlaceholderTest {
         when(bm.currencyLabel()).thenReturn("$");
         out = p.onPlaceholderRequest(null, "currency_symbol");
         assertEquals("$", out);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private static EzBoostPlugin mockPlugin() {
+        EzBoostPlugin plugin = mock(EzBoostPlugin.class);
+        PluginDescriptionFile desc = mock(PluginDescriptionFile.class);
+        when(desc.getAuthors()).thenReturn(List.of("me"));
+        when(desc.getVersion()).thenReturn("1.0.0");
+        when(plugin.getDescription()).thenReturn(desc);
+        return plugin;
+    }
+
+    // -------------------------------------------------------------------------
+    // has_active_boost / active_boost / active_boost_display
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void hasActiveBoost_trueWhenKeyPresent_falseWhenNull() {
+        BoostManager bm = mock(BoostManager.class);
+        when(bm.currencyFormatter()).thenReturn(new CurrencyFormatter(null));
+        Player player = mock(Player.class);
+        EzBoostPlaceholder p = new EzBoostPlaceholder(mockPlugin(), bm);
+
+        when(bm.getActiveBoostKey(player)).thenReturn("speed");
+        assertEquals("true", p.onPlaceholderRequest(player, "has_active_boost"));
+
+        when(bm.getActiveBoostKey(player)).thenReturn(null);
+        assertEquals("false", p.onPlaceholderRequest(player, "has_active_boost"));
+
+        // null player → false
+        assertEquals("false", p.onPlaceholderRequest(null, "has_active_boost"));
+    }
+
+    @Test
+    public void activeBoost_returnsKeyOrEmpty() {
+        BoostManager bm = mock(BoostManager.class);
+        when(bm.currencyFormatter()).thenReturn(new CurrencyFormatter(null));
+        Player player = mock(Player.class);
+        EzBoostPlaceholder p = new EzBoostPlaceholder(mockPlugin(), bm);
+
+        when(bm.getActiveBoostKey(player)).thenReturn("speed");
+        assertEquals("speed", p.onPlaceholderRequest(player, "active_boost"));
+
+        when(bm.getActiveBoostKey(player)).thenReturn(null);
+        assertEquals("", p.onPlaceholderRequest(player, "active_boost"));
+    }
+
+    @Test
+    public void activeBoostDisplay_returnsDisplayNameOrEmpty() {
+        BoostManager bm = mock(BoostManager.class);
+        when(bm.currencyFormatter()).thenReturn(new CurrencyFormatter(null));
+        Player player = mock(Player.class);
+        BoostDefinition def = new BoostDefinition(
+                "speed", "Speed Boost", Material.DIAMOND,
+                List.of(new BoostEffect(null, 0, null)),
+                new BoostCommands(List.of(), List.of(), List.of()),
+                60, 0, 100, null, true);
+        EzBoostPlaceholder p = new EzBoostPlaceholder(mockPlugin(), bm);
+
+        when(bm.getActiveBoostKey(player)).thenReturn("speed");
+        when(bm.getBoost("speed", player)).thenReturn(Optional.of(def));
+        assertEquals("Speed Boost", p.onPlaceholderRequest(player, "active_boost_display"));
+
+        when(bm.getActiveBoostKey(player)).thenReturn(null);
+        assertEquals("", p.onPlaceholderRequest(player, "active_boost_display"));
+    }
+
+    // -------------------------------------------------------------------------
+    // active_boost_time_remaining / active_boost_time_remaining_formatted
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void activeBoostTimeRemaining_rawAndFormatted() {
+        BoostManager bm = mock(BoostManager.class);
+        when(bm.currencyFormatter()).thenReturn(new CurrencyFormatter(null));
+        Player player = mock(Player.class);
+        EzBoostPlaceholder p = new EzBoostPlaceholder(mockPlugin(), bm);
+
+        when(bm.getActiveBoostTimeRemaining(player)).thenReturn(90L);
+        assertEquals("90", p.onPlaceholderRequest(player, "active_boost_time_remaining"));
+        assertEquals("01:30", p.onPlaceholderRequest(player, "active_boost_time_remaining_formatted"));
+
+        when(bm.getActiveBoostTimeRemaining(player)).thenReturn(3661L);
+        assertEquals("3661", p.onPlaceholderRequest(player, "active_boost_time_remaining"));
+        assertEquals("01:01:01", p.onPlaceholderRequest(player, "active_boost_time_remaining_formatted"));
+
+        // null player
+        assertEquals("0", p.onPlaceholderRequest(null, "active_boost_time_remaining"));
+        assertEquals("00:00", p.onPlaceholderRequest(null, "active_boost_time_remaining_formatted"));
+    }
+
+    // -------------------------------------------------------------------------
+    // is_active_<key>
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void isActive_delegatesToBoostManager() {
+        BoostManager bm = mock(BoostManager.class);
+        when(bm.currencyFormatter()).thenReturn(new CurrencyFormatter(null));
+        Player player = mock(Player.class);
+        EzBoostPlaceholder p = new EzBoostPlaceholder(mockPlugin(), bm);
+
+        when(bm.isActive(player, "speed")).thenReturn(true);
+        assertEquals("true", p.onPlaceholderRequest(player, "is_active_speed"));
+
+        when(bm.isActive(player, "speed")).thenReturn(false);
+        assertEquals("false", p.onPlaceholderRequest(player, "is_active_speed"));
+
+        assertEquals("false", p.onPlaceholderRequest(null, "is_active_speed"));
+    }
+
+    // -------------------------------------------------------------------------
+    // cooldown_remaining_<key> / cooldown_remaining_formatted_<key>
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void cooldownRemaining_rawAndFormatted() {
+        BoostManager bm = mock(BoostManager.class);
+        when(bm.currencyFormatter()).thenReturn(new CurrencyFormatter(null));
+        Player player = mock(Player.class);
+        EzBoostPlaceholder p = new EzBoostPlaceholder(mockPlugin(), bm);
+
+        when(bm.getCooldownRemaining(player, "speed")).thenReturn(90L);
+        assertEquals("90", p.onPlaceholderRequest(player, "cooldown_remaining_speed"));
+        assertEquals("01:30", p.onPlaceholderRequest(player, "cooldown_remaining_formatted_speed"));
+
+        when(bm.getCooldownRemaining(player, "speed")).thenReturn(0L);
+        assertEquals("0", p.onPlaceholderRequest(player, "cooldown_remaining_speed"));
+        assertEquals("00:00", p.onPlaceholderRequest(player, "cooldown_remaining_formatted_speed"));
+
+        // null player
+        assertEquals("0", p.onPlaceholderRequest(null, "cooldown_remaining_speed"));
+        assertEquals("00:00", p.onPlaceholderRequest(null, "cooldown_remaining_formatted_speed"));
+    }
+
+    // -------------------------------------------------------------------------
+    // xp_multiplier
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void xpMultiplier_returnsOneWhenNotRegistered() {
+        BoostManager bm = mock(BoostManager.class);
+        when(bm.currencyFormatter()).thenReturn(new CurrencyFormatter(null));
+        // Ensure EzBoostAPI has no boostManager → getCustomBoostEffects() returns empty map
+        EzBoostAPI.init(null);
+        EzBoostPlaceholder p = new EzBoostPlaceholder(mockPlugin(), bm);
+        assertEquals("1", p.onPlaceholderRequest(mock(Player.class), "xp_multiplier"));
+    }
+
+    @Test
+    public void xpMultiplier_returnsMultiplierWhenBoostActive() {
+        BoostManager bm = mock(BoostManager.class);
+        when(bm.currencyFormatter()).thenReturn(new CurrencyFormatter(null));
+
+        XpBoostEffect xpEffect = new XpBoostEffect();
+        Player player = mock(Player.class);
+        UUID uuid = UUID.randomUUID();
+        when(player.getUniqueId()).thenReturn(uuid);
+        xpEffect.apply(player, 0); // amplifier 0 → multiplier 2
+
+        Map<String, CustomBoostEffect> effects = new HashMap<>();
+        effects.put("xpboost", xpEffect);
+        when(bm.getCustomEffects()).thenReturn(effects);
+        EzBoostAPI.init(bm);
+
+        EzBoostPlaceholder p = new EzBoostPlaceholder(mockPlugin(), bm);
+        assertEquals("2", p.onPlaceholderRequest(player, "xp_multiplier"));
+
+        EzBoostAPI.init(null); // cleanup
     }
 }


### PR DESCRIPTION
## Placeholders & Messages

### New internal message tags (no PlaceholderAPI required)

Boost-context messages in `messages.yml` now support additional tags automatically.
You can use these in any message that relates to a specific boost:

| Tag | Example output |
|-----|----------------|
| `<boost>` / `<boost_display>` | `Speed Boost` |
| `<boost_key>` | `speed` |
| `<boost_cost>` | `50,000` |
| `<boost_cost_compact>` | `50K` |
| `<boost_cost_raw>` | `50000` |
| `<boost_duration>` | `120` |
| `<boost_cooldown>` | `60` |

Available in: `boost-activated`, `boost-expired`, `boost-cooldown`, `boost-effect-cooldown`, `insufficient-funds`, `cost-charged`, `token-used`.

### Bug fix: `<boost>` now shows display name everywhere

Previously `boost-expired`, `cost-charged`, and `token-used` showed the internal config key (e.g. `speed`) instead of the configured display name (e.g. `Speed Boost`). This is now fixed. Use `<boost_key>` if you specifically need the raw config key.

### 9 new PlaceholderAPI placeholders

Requires PlaceholderAPI to be installed.

| Placeholder | Returns |
|-------------|---------|
| `%ezboost_has_active_boost%` | `true` or `false` |
| `%ezboost_active_boost%` | Config key of the active boost, or empty |
| `%ezboost_active_boost_display%` | Display name of the active boost, or empty |
| `%ezboost_active_boost_time_remaining%` | Seconds remaining as a number |
| `%ezboost_active_boost_time_remaining_formatted%` | `MM:SS` or `HH:MM:SS` |
| `%ezboost_is_active_<boostkey>%` | `true` or `false` |
| `%ezboost_cooldown_remaining_<boostkey>%` | Cooldown seconds as a number |
| `%ezboost_cooldown_remaining_formatted_<boostkey>%` | `MM:SS` or `HH:MM:SS` |
| `%ezboost_xp_multiplier%` | Active XP multiplier (`1` if no XP boost is running) |

Example uses:

- Scoreboard line: `Boost: %ezboost_active_boost_display% (%ezboost_active_boost_time_remaining_formatted%)`
- Condition check: show a button only when `%ezboost_has_active_boost%` equals `false`
- XP display: `XP rate: %ezboost_xp_multiplier%x`