### PR TITLE
Jekyll site, lint/coverage workflows, and Jaloquent-style badge updates

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,40 @@
+name: Code Quality
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+    branches: ["main", "master"]
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+          cache: maven
+
+      - name: Build with coverage
+        run: mvn --batch-mode clean verify
+
+      - name: Upload JaCoCo coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco/
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/site/jacoco/jacoco.xml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Documentation
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+# Required for GitHub Pages deployment via Actions
+permissions:
+  contents: read
+  pages:    write
+  id-token: write
+
+# Allow only one concurrent deployment; skip in-progress runs
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build Jekyll site
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source:      ./docs
+          destination: ./_site
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - "docs/**/*.md"
+      - ".markdownlint.yml"
+
+jobs:
+  markdown:
+    name: Validate Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint documentation Markdown
+        uses: DavidAnson/markdownlint-cli2-action@v16
+        with:
+          globs: "docs/**/*.md"
+          config: ".markdownlint.yml"

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,34 @@
+# markdownlint configuration
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+default: true
+
+# MD013 — Line length: documentation lines are allowed to exceed 80 chars
+MD013: false
+
+# MD022 — Blanks around headings: Kramdown attribute syntax ({: .no_toc })
+#          must immediately follow a heading with no blank line
+MD022: false
+
+# MD025 — Single H1: pages have both front-matter title: and an # H1 heading;
+#          disable front-matter title detection to avoid false positives
+MD025:
+  front_matter_title: ""
+
+# MD033 — Inline HTML: needed for Jekyll/Liquid includes and badge images
+MD033: false
+
+# MD036 — Emphasis as heading: API tables use bold labels that markdownlint
+#          mistakes for headings
+MD036: false
+
+# MD041 — First line must be H1: front-matter pages don't start with a heading
+MD041: false
+
+# MD024 — No duplicate headings: allow sibling duplicates across sections
+MD024:
+  siblings_only: true
+
+# MD007 — Unordered list indentation: use 2-space indent under list items
+MD007:
+  indent: 2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-[![Platform: Spigot | Paper | Bukkit](https://img.shields.io/badge/Platform-Spigot%20%7C%20Paper%20%7C%20Bukkit-blue?style=flat-square)](#)
-[![Minecraft 1.7-1.21.*](https://img.shields.io/badge/Minecraft-1.7--1.21.*-brightgreen?style=flat-square)](#)
-[![MIT License](https://img.shields.io/github/license/ez-plugins/ezboost?style=flat-square)](#)
-[![Latest Release](https://img.shields.io/github/v/release/ez-plugins/ezboost?style=flat-square)](#)
+[![CI](https://github.com/ez-plugins/ezboost/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/ez-plugins/ezboost/actions/workflows/smoke-test.yml)
+[![GitHub Packages](https://img.shields.io/badge/GitHub_Packages-2.0.0-blue?logo=github)](https://github.com/ez-plugins/ezboost/packages)
+[![Coverage](https://img.shields.io/codecov/c/github/ez-plugins/ezboost)](https://codecov.io/github/ez-plugins/ezboost)
+[![Docs](https://img.shields.io/badge/Docs-GitHub_Pages-blue?logo=github)](https://ez-plugins.github.io/ezboost)
+[![Platform](https://img.shields.io/badge/Platform-Spigot%20%7C%20Paper%20%7C%20Bukkit-blue)](#)
+[![Minecraft](https://img.shields.io/badge/Minecraft-1.7--1.21.*-brightgreen)](#)
+[![License](https://img.shields.io/github/license/ez-plugins/ezboost)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/ez-plugins/ezboost)](https://github.com/ez-plugins/ezboost/releases)
 
 # EzBoost
 
@@ -34,18 +38,19 @@ EzBoost is a modern, production-ready Minecraft plugin for Spigot, Paper, and Bu
 
 ## Documentation
 
-- [Commands Reference](docs/commands.md)
-- [Permissions Reference](docs/permissions.md)
-- [Overrides Guide](docs/overrides.md)
-- [GUI Guide](docs/gui.md)
-- [Configuration Guide](docs/config.md)
-- [Boosts Guide](docs/boosts.md)
-- [API Overview](docs/api.md)
-  - [EzBoostAPI Reference](docs/api/EzBoostAPI.md)
-  - [CustomBoostEffect Reference](docs/api/CustomBoostEffect.md)
-  - [Events Overview](docs/events.md)
-    - [BoostStartEvent Reference](docs/events/BoostStartEvent.md)
-    - [BoostEndEvent Reference](docs/events/BoostEndEvent.md)
+Full documentation is available at **<https://ez-plugins.github.io/ezboost>**.
+
+| Page | What it covers |
+|------|----------------|
+| [Commands](https://ez-plugins.github.io/ezboost/commands) | All `/boost` and `/ezboost` commands |
+| [Permissions](https://ez-plugins.github.io/ezboost/permissions) | Permissions reference and defaults |
+| [Configuration](https://ez-plugins.github.io/ezboost/config) | `settings.yml`, `limits.yml`, `worlds.yml`, `economy.yml` |
+| [Boosts](https://ez-plugins.github.io/ezboost/boosts) | `boosts.yml` schema — effects, durations, costs |
+| [GUI](https://ez-plugins.github.io/ezboost/gui) | `gui.yml` — chest-based boost menu |
+| [Overrides](https://ez-plugins.github.io/ezboost/overrides) | World, group, and region multiplier overrides |
+| [Events](https://ez-plugins.github.io/ezboost/events) | Plugin lifecycle events |
+| [API](https://ez-plugins.github.io/ezboost/api) | Developer API reference |
+| [PlaceholderAPI](https://ez-plugins.github.io/ezboost/integration/PlaceholderAPI) | Available placeholders |
 
 ---
 

--- a/docs/EzBoostAPI.md
+++ b/docs/EzBoostAPI.md
@@ -10,10 +10,13 @@ EzBoost exposes a professional, extensible API for plugin developers and advance
 ## Getting Started
 
 1. Register your custom effect:
+
    ```java
    EzBoostAPI.registerCustomEffect(new MyCustomEffect());
    ```
+
 2. Query or manage player boosts:
+
    ```java
    if (EzBoostAPI.isBoostActive(player)) {
        BoostDefinition boost = EzBoostAPI.getActiveBoost(player);

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,62 @@
+remote_theme: just-the-docs/just-the-docs
+
+title: EzBoost
+description: >-
+  Modern, production-ready Minecraft boost plugin for Spigot, Paper, and Bukkit.
+  Configurable potion boosts, cooldowns, GUI, economy integration, and WorldGuard support.
+
+url: "https://ez-plugins.github.io"
+baseurl: "/ezboost"
+
+# ── Appearance ────────────────────────────────────────────────────────────────
+heading_anchors: true
+
+# ── Header links ──────────────────────────────────────────────────────────────
+aux_links:
+  "GitHub":
+    - "https://github.com/ez-plugins/ezboost"
+  "Releases":
+    - "https://github.com/ez-plugins/ezboost/releases"
+
+aux_links_new_tab: true
+
+# ── Navigation ────────────────────────────────────────────────────────────────
+nav_sort: case_insensitive
+nav_external_links:
+  - title: Changelog
+    url: "https://github.com/ez-plugins/ezboost/releases"
+    hide_icon: false
+
+# ── Search ────────────────────────────────────────────────────────────────────
+search_enabled: true
+search:
+  heading_level:        2
+  previews:             3
+  preview_words_before: 5
+  preview_words_after:  10
+  tokenizer_separator:  /[\s/]+/
+
+# ── Footer ────────────────────────────────────────────────────────────────────
+back_to_top:      true
+back_to_top_text: "Back to top"
+
+footer_content: >-
+  Copyright &copy; 2024&ndash;2026 EzPlugins.
+  Distributed under the
+  <a href="https://github.com/ez-plugins/ezboost/blob/main/LICENSE">MIT License</a>.
+
+# ── Kramdown ──────────────────────────────────────────────────────────────────
+kramdown:
+  syntax_highlighter_opts:
+    block:
+      line_numbers: false
+
+# ── Plugins ───────────────────────────────────────────────────────────────────
+plugins:
+  - jekyll-remote-theme
+  - jekyll-seo-tag
+
+# ── Build exclusions ──────────────────────────────────────────────────────────
+exclude:
+  - Gemfile
+  - Gemfile.lock

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,20 @@
+---
+title: API
+nav_order: 9
+has_children: true
+description: "EzBoost developer API — integrating boost management into your own plugins"
+---
+
 # EzBoost API Overview
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 EzBoost exposes a professional, extensible API for plugin developers and advanced users. The API allows you to register custom boost effects, manage player boosts, and integrate deeply with the boost system.
 
@@ -6,7 +22,6 @@ EzBoost exposes a professional, extensible API for plugin developers and advance
 
 - [`EzBoostAPI`](api/EzBoostAPI.md): Main static API class for registering effects, querying and managing boosts.
 - [`CustomBoostEffect`](api/CustomBoostEffect.md): Interface for defining custom boost effects.
-
 
 ## Configuring Custom Effects in YAML
 
@@ -44,12 +59,14 @@ You can use JitPack to include the latest version directly from GitHub:
 </dependency>
 ```
 
-### 2. Register your custom effect:
+### 2. Register your custom effect
+
 ```java
 EzBoostAPI.registerCustomEffect(new MyCustomEffect());
 ```
 
-### 3. Query or manage player boosts:
+### 3. Query or manage player boosts
+
 ```java
 if (EzBoostAPI.isBoostActive(player)) {
    BoostDefinition boost = EzBoostAPI.getActiveBoost(player);

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,20 @@
+---
+title: API
+nav_order: 9
+has_children: true
+description: "EzBoost developer API — integrating boost management into your own plugins"
+---
+
 # EzBoost API Overview
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 EzBoost exposes a professional, extensible API for plugin developers and advanced users. The API allows you to register custom boost effects, manage player boosts, and integrate deeply with the boost system.
 

--- a/docs/api/CustomBoostEffect.md
+++ b/docs/api/CustomBoostEffect.md
@@ -1,4 +1,20 @@
+---
+title: CustomBoostEffect
+parent: API
+nav_order: 2
+description: "CustomBoostEffect interface — implementing custom plugin-driven boost effects"
+---
+
 # CustomBoostEffect Interface Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 ## Overview
 `CustomBoostEffect` is an interface for defining custom boost effects that can be registered with EzBoost. Implement this interface in your plugin to add new effect types that will be executed when a boost is activated or deactivated.

--- a/docs/api/CustomBoostEffect.md
+++ b/docs/api/CustomBoostEffect.md
@@ -1,4 +1,20 @@
+---
+title: CustomBoostEffect
+parent: API
+nav_order: 2
+description: "CustomBoostEffect interface — implementing custom plugin-driven boost effects"
+---
+
 # CustomBoostEffect Interface Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 ## Overview
 `CustomBoostEffect` is an interface for defining custom boost effects that can be registered with EzBoost. Implement this interface in your plugin to add new effect types that will be executed when a boost is activated or deactivated.
@@ -7,6 +23,7 @@
 `com.skyblockexp.ezboost.boost`
 
 ## Interface Declaration
+
 ```java
 public interface CustomBoostEffect {
     /**
@@ -40,10 +57,12 @@ public interface CustomBoostEffect {
 
 ### `void apply(Player player, int amplifier)`
 Called when the boost's custom effect should be applied to a player.
+
 - **player**: The player receiving the effect.
 - **amplifier**: The configured amplifier for this effect in the boost.
 
 **Usage Example:**
+
 ```java
 @Override
 public void apply(Player player, int amplifier) {
@@ -55,9 +74,11 @@ public void apply(Player player, int amplifier) {
 
 ### `void remove(Player player)`
 Called when the boost's custom effect should be removed from a player.
+
 - **player**: The player losing the effect.
 
 **Usage Example:**
+
 ```java
 @Override
 public void remove(Player player) {
@@ -69,12 +90,14 @@ public void remove(Player player) {
 
 ### `String getName()`
 Returns the unique effect name used in boost configuration to identify the custom effect.
+
 - **Returns**: The effect name (e.g., "mycustom").
 
 ### `int getCooldownSeconds()`
 Returns the cooldown duration (in seconds) associated with this custom effect. When `settings.cooldown-per-effect` is enabled, this value is used to set per-effect cooldown timestamps after activation. Returning `0` means no cooldown.
 
 **Usage Example:**
+
 ```java
 @Override
 public String getName() {
@@ -119,6 +142,7 @@ public void onEnable() {
 ```
 
 ## Notes
+
 - Register your implementation with `EzBoostAPI.registerCustomEffect()` (see example above).
 - The effect type returned by `getType()` must be unique across all registered effects.
 - See also: [EzBoostAPI](../EzBoostAPI.md)

--- a/docs/api/EzBoostAPI.md
+++ b/docs/api/EzBoostAPI.md
@@ -1,4 +1,20 @@
+---
+title: EzBoostAPI
+parent: API
+nav_order: 1
+description: "EzBoostAPI class reference — full public method tables"
+---
+
 # EzBoostAPI Class Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 ## Overview
 `EzBoostAPI` is the main static API class for interacting with the EzBoost plugin. It provides methods for registering custom boost effects, querying and managing player boosts, and integrating with the boost system from other plugins.
@@ -7,6 +23,7 @@
 `com.skyblockexp.ezboost.api`
 
 ## Class Declaration
+
 ```java
 public final class EzBoostAPI {
     // Static utility class
@@ -17,10 +34,12 @@ public final class EzBoostAPI {
 
 ### `static boolean registerCustomBoostEffect(CustomBoostEffect effect)`
 Register a custom boost effect implementation so other plugins can provide new effect types.
+
 - **effect**: The `CustomBoostEffect` implementation to register.
 - **Returns**: `true` if registration succeeded; `false` if the API isn't initialized or the effect name is already registered.
 
 **Usage Example:**
+
 ```java
 boolean ok = EzBoostAPI.registerCustomBoostEffect(new MyCustomEffect());
 ```
@@ -31,6 +50,7 @@ boolean ok = EzBoostAPI.registerCustomBoostEffect(new MyCustomEffect());
 Returns an unmodifiable map of all registered custom boost effects keyed by their normalized names.
 
 **Usage Example:**
+
 ```java
 Map<String, CustomBoostEffect> effects = EzBoostAPI.getCustomBoostEffects();
 ```
@@ -41,6 +61,7 @@ Map<String, CustomBoostEffect> effects = EzBoostAPI.getCustomBoostEffects();
 Returns the internal `BoostManager` instance. This exposes advanced integration points but should be used carefully.
 
 **Usage Example:**
+
 ```java
 BoostManager manager = EzBoostAPI.getBoostManager();
 ```
@@ -51,10 +72,13 @@ BoostManager manager = EzBoostAPI.getBoostManager();
 Convenience helper that returns remaining cooldown (in seconds) for a specific `BoostEffect` on a player. Returns `0` if no cooldown is present or the API is not initialized.
 
 **Usage Example:**
+
 ```java
 long remaining = EzBoostAPI.getCooldownRemainingForEffect(player, myBoostEffect);
 ```
+
 ## Notes
+
 - All methods are static for ease of use.
 - Designed for open-source extensibility and professional integrations.
 - Register custom effects before any boosts are activated.

--- a/docs/api/EzBoostAPI.md
+++ b/docs/api/EzBoostAPI.md
@@ -1,4 +1,20 @@
+---
+title: EzBoostAPI
+parent: API
+nav_order: 1
+description: "EzBoostAPI class reference — full public method tables"
+---
+
 # EzBoostAPI Class Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 ## Overview
 `EzBoostAPI` is the main static API class for interacting with the EzBoost plugin. It provides methods for registering custom boost effects, querying and managing player boosts, and integrating with the boost system from other plugins.

--- a/docs/boosts.md
+++ b/docs/boosts.md
@@ -1,4 +1,19 @@
+---
+title: Boosts
+nav_order: 5
+description: "boosts.yml schema — defining effects, durations, cooldowns, costs, and particles"
+---
+
 # EzBoost – Default Boosts Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 This document describes the default boosts provided in `boosts.yml` for EzBoost. Each boost can be customized or extended in your configuration.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,4 +1,19 @@
+---
+title: Commands
+nav_order: 2
+description: "All /boost and /ezboost commands with syntax, arguments, and permissions"
+---
+
 # EzBoost Commands
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 This document details all commands provided by EzBoost, including syntax, arguments, permissions, and usage examples.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,52 +1,80 @@
+---
+title: Commands
+nav_order: 2
+description: "All /boost and /ezboost commands with syntax, arguments, and permissions"
+---
+
 # EzBoost Commands
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 This document details all commands provided by EzBoost, including syntax, arguments, permissions, and usage examples.
 
 ## Player Commands
 
 ### `/boost`
+
 - **Description**: Opens the boosts GUI where players can browse and activate available boosts. If the GUI is disabled, displays usage information.
 - **Permission**: `ezboost.use`
 - **Usage**: `/boost`
 - **Example**:
-  ```
+
+  ```text
   /boost
   ```
+
   Opens the interactive boosts menu.
 
 ### `/boost <boostKey>`
+
 - **Description**: Directly activates a specific boost by its key, bypassing the GUI.
 - **Permission**: `ezboost.use` + `ezboost.boost.<boostKey>` (per-boost permission)
 - **Usage**: `/boost <boostKey>`
 - **Example**:
-  ```
+
+  ```text
   /boost speed
   ```
+
   Activates the "speed" boost if available and permitted.
 
 ## Admin Commands
 
 ### `/ezboost create`
+
 - **Description**: Opens the admin GUI for creating and managing boosts. Allows administrators to define new boosts with effects, durations, cooldowns, and more.
 - **Permission**: `ezboost.admin`
 - **Usage**: `/ezboost create`
 - **Example**:
-  ```
+
+  ```text
   /ezboost create
   ```
+
   Opens the boost creation interface.
 
 ### `/ezboost reload`
+
 - **Description**: Reloads all configuration files and messages at runtime without restarting the server.
 - **Permission**: `ezboost.reload`
 - **Usage**: `/ezboost reload`
 - **Example**:
-  ```
+
+  ```text
   /ezboost reload
   ```
+
   Reloads boosts.yml, gui.yml, messages.yml, and other config files.
 
 ### `/ezboost give <player> <boostKey> [amount]`
+
 - **Description**: Gives boost token items to a player. Tokens can be redeemed by right-clicking them to activate the boost.
 - **Permission**: `ezboost.give`
 - **Usage**: `/ezboost give <player> <boostKey> [amount]`
@@ -55,9 +83,11 @@ This document details all commands provided by EzBoost, including syntax, argume
   - `<boostKey>`: The key of the boost to give tokens for
   - `[amount]`: Optional amount of tokens (default: 1)
 - **Example**:
-  ```
+
+  ```text
   /ezboost give Steve speed 5
   ```
+
   Gives 5 speed boost tokens to player Steve.
 
 For detailed permissions documentation, see [docs/permissions.md](permissions.md).

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,4 +1,19 @@
+---
+title: Configuration
+nav_order: 4
+description: "settings.yml, limits.yml, worlds.yml, and economy.yml configuration reference"
+---
+
 # EzBoost – Configuration Options Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 This document provides a complete reference for all configuration files and options available in EzBoost. Use this guide to understand and customize every aspect of the plugin.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -20,6 +20,7 @@ This document provides a complete reference for all configuration files and opti
 ---
 
 ## Table of Contents
+
 - [settings.yml](#settingsyml)
 - [limits.yml](#limitsyml)
 - [worlds.yml](#worldsyml)
@@ -52,6 +53,7 @@ settings:
 ```
 
 Behavior:
+
 - `cooldown-per-boost-type: true` (legacy) keeps the existing per-boost-type cooldown behavior.
 - `cooldown-per-effect: true` enables per-effect cooldown checks. Lookups will fall back to the boost-level/global cooldown if no effect-specific cooldown is present.
 
@@ -80,6 +82,7 @@ worlds:
   allow-list: []   # List of world names where boosts are allowed (empty = all worlds allowed)
   deny-list: []    # List of world names where boosts are denied (empty = no worlds denied)
 ```
+
 - If both lists are empty, boosts are allowed in all worlds.
 - If a world appears in both lists, deny-list takes priority.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,4 +1,20 @@
+---
+title: Events
+nav_order: 8
+has_children: true
+description: "Plugin events emitted by EzBoost — overview and usage guide"
+---
+
 # EzBoost Events Overview
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 EzBoost provides a robust event system to allow other plugins and advanced users to hook into boost lifecycle changes. This enables custom logic, integrations, and advanced control over boost activation and deactivation.
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -26,6 +26,7 @@ EzBoost provides a robust event system to allow other plugins and advanced users
 ## Event Firing Scenarios
 
 Events are fired in all scenarios where a boost may start or end, including:
+
 - Manual activation
 - Expiry (time runs out)
 - Player join (re-application)
@@ -48,5 +49,6 @@ public void onBoostStart(BoostStartEvent event) {
 ```
 
 See the advanced class reference for each event:
+
 - [BoostStartEvent](events/BoostStartEvent.md)
 - [BoostEndEvent](events/BoostEndEvent.md)

--- a/docs/events/BoostEndEvent.md
+++ b/docs/events/BoostEndEvent.md
@@ -23,6 +23,7 @@ description: "Event fired when a boost expires or is cancelled — fields and us
 `com.skyblockexp.ezboost.event`
 
 ## Class Declaration
+
 ```java
 public class BoostEndEvent extends Event implements Cancellable {
     public BoostEndEvent(Player player, String boostKey, BoostDefinition boostDefinition);
@@ -31,6 +32,7 @@ public class BoostEndEvent extends Event implements Cancellable {
 ```
 
 ## Key Methods & Fields
+
 - `Player getPlayer()` — The player whose boost is ending.
 - `String getBoostKey()` — The unique key of the boost.
 - `BoostDefinition getBoostDefinition()` — The full boost definition.
@@ -38,6 +40,7 @@ public class BoostEndEvent extends Event implements Cancellable {
 - `void setCancelled(boolean cancel)` — Cancel or allow the boost end.
 
 ## Usage Example
+
 ```java
 @EventHandler
 public void onBoostEnd(BoostEndEvent event) {
@@ -48,5 +51,6 @@ public void onBoostEnd(BoostEndEvent event) {
 ```
 
 ## Notes
+
 - Fired in all scenarios where a boost may end (expiry, death, region/world change, forced removal, etc.).
 - Always provides the full `BoostDefinition` for advanced integrations.

--- a/docs/events/BoostEndEvent.md
+++ b/docs/events/BoostEndEvent.md
@@ -1,4 +1,20 @@
+---
+title: BoostEndEvent
+parent: Events
+nav_order: 2
+description: "Event fired when a boost expires or is cancelled — fields and usage"
+---
+
 # BoostEndEvent Class Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 ## Overview
 `BoostEndEvent` is fired when a boost is about to end for a player. This event is cancellable, allowing plugins to prevent the boost from ending. It provides full context, including the player and the `BoostDefinition`.

--- a/docs/events/BoostStartEvent.md
+++ b/docs/events/BoostStartEvent.md
@@ -1,4 +1,20 @@
+---
+title: BoostStartEvent
+parent: Events
+nav_order: 1
+description: "Event fired when a boost is activated — fields, cancellation, and usage"
+---
+
 # BoostStartEvent Class Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 ## Overview
 `BoostStartEvent` is fired when a boost is about to start for a player. This event is cancellable, allowing plugins to prevent the boost from activating. It provides full context, including the player and the `BoostDefinition`.

--- a/docs/events/BoostStartEvent.md
+++ b/docs/events/BoostStartEvent.md
@@ -23,6 +23,7 @@ description: "Event fired when a boost is activated — fields, cancellation, an
 `com.skyblockexp.ezboost.event`
 
 ## Class Declaration
+
 ```java
 public class BoostStartEvent extends Event implements Cancellable {
     public BoostStartEvent(Player player, String boostKey, BoostDefinition boostDefinition);
@@ -31,6 +32,7 @@ public class BoostStartEvent extends Event implements Cancellable {
 ```
 
 ## Key Methods & Fields
+
 - `Player getPlayer()` — The player receiving the boost.
 - `String getBoostKey()` — The unique key of the boost.
 - `BoostDefinition getBoostDefinition()` — The full boost definition.
@@ -38,6 +40,7 @@ public class BoostStartEvent extends Event implements Cancellable {
 - `void setCancelled(boolean cancel)` — Cancel or allow the boost start.
 
 ## Usage Example
+
 ```java
 @EventHandler
 public void onBoostStart(BoostStartEvent event) {
@@ -48,5 +51,6 @@ public void onBoostStart(BoostStartEvent event) {
 ```
 
 ## Notes
+
 - Fired in all scenarios where a boost may start (activation, join, replacement, etc.).
 - Always provides the full `BoostDefinition` for advanced integrations.

--- a/docs/gui.md
+++ b/docs/gui.md
@@ -1,4 +1,19 @@
+---
+title: GUI
+nav_order: 6
+description: "gui.yml schema — configuring the interactive chest-based boost menu"
+---
+
 # EzBoost – GUI Configuration Reference
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 This document explains all options available in `gui.yml` for EzBoost. Use this as a guide to customize the in-game boost selection menu.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,66 @@
+---
+layout: home
+title: EzBoost
+nav_order: 1
+description: "Modern Minecraft boost plugin for Spigot, Paper, and Bukkit"
+permalink: /
+---
+
+# EzBoost
+
+[![CI](https://github.com/ez-plugins/ezboost/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/ez-plugins/ezboost/actions/workflows/smoke-test.yml)
+[![GitHub Packages](https://img.shields.io/badge/GitHub_Packages-2.0.0-blue?logo=github)](https://github.com/ez-plugins/ezboost/packages)
+[![Coverage](https://img.shields.io/codecov/c/github/ez-plugins/ezboost)](https://codecov.io/github/ez-plugins/ezboost)
+
+**EzBoost** is a modern, production-ready Minecraft plugin for Spigot, Paper, and Bukkit servers (1.7–1.21.*).
+It gives server owners full control over configurable, time-limited potion boosts — complete with GUI,
+cooldowns, economy integration, WorldGuard region support, and a developer API.
+
+---
+
+## Features
+
+- **Flexible boost definitions** — configure any potion effect with duration, amplifier, cooldowns, limits, and particle effects via `boosts.yml`
+- **Interactive GUI** — fully-customisable chest-based boost menu driven by `gui.yml`; fully disableable
+- **Economy integration** — optional Vault economy support with per-boost pricing; gracefully skipped when Vault is absent
+- **WorldGuard support** — restrict boost activation to specific WorldGuard regions
+- **Per-player and global limits** — cap how many active boosts a player or the server can run simultaneously
+- **Overrides** — server-wide event-driven multipliers layered on top of individual boosts
+- **PlaceholderAPI** — exposes boost state and duration as placeholders for scoreboards, holograms, and more
+- **MiniMessage formatting** — all messages use the Adventure MiniMessage format for rich, hex-colour text
+- **Developer API** — clean Java API to start/stop boosts and listen to lifecycle events from other plugins
+
+---
+
+## Quick start
+
+**1. Download the plugin:**
+
+Grab the latest `EzBoost-x.y.z.jar` from [Releases](https://github.com/ez-plugins/ezboost/releases)
+and drop it into your server's `plugins/` directory.
+
+**2. Start your server once** to generate default configuration files in `plugins/EzBoost/`.
+
+**3. Edit `boosts.yml`** to define your server's boost types, then **edit `settings.yml`** to enable economy or WorldGuard if needed.
+
+**4. Reload with `/ezboost reload`** (requires `ezboost.admin`).
+
+---
+
+## Documentation
+
+| Page | What it covers |
+|------|----------------|
+| [Commands](commands) | All `/boost` and `/ezboost` commands with syntax and permissions |
+| [Permissions](permissions) | Full permissions reference and default values |
+| [Configuration](config) | `settings.yml`, `limits.yml`, `worlds.yml`, `economy.yml` |
+| [Boosts](boosts) | `boosts.yml` schema — effects, duration, cooldowns, costs |
+| [GUI](gui) | `gui.yml` schema — slots, items, actions |
+| [Overrides](overrides) | Server-wide boost multiplier overrides |
+| [Events](events) | Plugin events overview |
+| &nbsp;&nbsp;[BoostStartEvent](events/BoostStartEvent) | Fired when a boost activates |
+| &nbsp;&nbsp;[BoostEndEvent](events/BoostEndEvent) | Fired when a boost expires or is cancelled |
+| [API](api) | EzBoost developer API overview |
+| &nbsp;&nbsp;[EzBoostAPI](api/EzBoostAPI) | Full public-method reference |
+| &nbsp;&nbsp;[CustomBoostEffect](api/CustomBoostEffect) | Implementing custom boost effects |
+| [PlaceholderAPI](integration/PlaceholderAPI) | Available placeholders and usage |

--- a/docs/integration/PlaceholderAPI.md
+++ b/docs/integration/PlaceholderAPI.md
@@ -19,7 +19,7 @@ This document describes the PlaceholderAPI expansion bundled with EzBoost and th
 
 ## Installation
 
-- Ensure PlaceholderAPI is installed on the server (https://www.spigotmc.org/resources/placeholderapi.6245/).
+- Ensure PlaceholderAPI is installed on the server (<https://www.spigotmc.org/resources/placeholderapi.6245/>).
 - The EzBoost expansion is registered automatically when both EzBoost and PlaceholderAPI are present — no extra files required.
 
 ## Expansion identifier
@@ -78,6 +78,7 @@ All placeholders use the `ezboost` expansion identifier. Wrap the identifier in 
 ## Formatting behaviour
 
 Number formatting honours `economy.format.*` settings from `economy.yml`:
+
 - `grouping` — `true`/`false`, enable thousands grouping
 - `grouping-separator` — single character, default `,`
 - `decimal-separator` — single character, default `.`
@@ -90,27 +91,32 @@ Compact formatting (`price_compact`) uses K / M suffixes and ignores the decimal
 ## Examples
 
 **Scoreboard line showing active boost and time:**
-```
+
+```text
 Boost: %ezboost_active_boost_display% (%ezboost_active_boost_time_remaining_formatted%)
 ```
 
 **Conditional button (e.g. in a GUI plugin) — only visible when no boost is active:**
-```
+
+```text
 condition: %ezboost_has_active_boost% == false
 ```
 
 **Shop sign showing cost:**
-```
+
+```text
 Cost: %ezboost_price_formatted_speed%
 ```
 
 **XP rate display:**
-```
+
+```text
 XP rate: %ezboost_xp_multiplier%x
 ```
 
 **Cooldown display for a specific boost:**
-```
+
+```text
 Cooldown: %ezboost_cooldown_remaining_formatted_speed%
 ```
 
@@ -121,4 +127,3 @@ Cooldown: %ezboost_cooldown_remaining_formatted_speed%
 - All boost key lookups use the requesting player's world/region context, so results may differ depending on active overrides.
 - If a boost key cannot be resolved or an argument is invalid, the placeholder returns an empty string (`""`), `false`, or `0` depending on the placeholder type.
 - The expansion registers at plugin startup when PlaceholderAPI is present; no manual registration is required.
-

--- a/docs/integration/PlaceholderAPI.md
+++ b/docs/integration/PlaceholderAPI.md
@@ -1,5 +1,19 @@
+---
+title: PlaceholderAPI
+nav_order: 10
+description: "PlaceholderAPI expansion for EzBoost — available placeholders and examples"
+---
 
 # PlaceholderAPI integration
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 This document describes the PlaceholderAPI expansion bundled with EzBoost and the placeholders it exposes.
 

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -18,6 +18,7 @@ description: "Server-wide boost multiplier overrides by world, world group, and 
 EzBoost supports advanced configuration overrides for boosts based on world, world group, and WorldGuard region. This allows you to customize boost behavior for specific worlds or protected regions on your server.
 
 ## Table of Contents
+
 - [Boost Overrides: Worlds, Groups, and Regions](#boost-overrides-worlds-groups-and-regions)
   - [Table of Contents](#table-of-contents)
   - [Overview](#overview)
@@ -75,6 +76,7 @@ When a player is in a region/world/group with overrides, the plugin uses the fol
 
 ## Examples
 ### Per-World Override
+
 ```yaml
 overrides:
   worlds:
@@ -85,6 +87,7 @@ overrides:
 ```
 
 ### Per-WorldGroup Override
+
 ```yaml
 overrides:
   worldgroups:
@@ -94,6 +97,7 @@ overrides:
 ```
 
 ### Per-Region Override
+
 ```yaml
 overrides:
   regions:
@@ -103,11 +107,13 @@ overrides:
 ```
 
 ## WorldGuard Region Support
+
 - Region overrides require WorldGuard to be installed.
 - The plugin uses the highest-priority region the player is in.
 - If WorldGuard is not present, region overrides are ignored.
 
 ## Best Practices
+
 - Only specify override fields you want to change; all other settings inherit from the global boost definition.
 - Use region overrides for spawn, PvP arenas, or special protected areas.
 - Use worldgroups to manage multiple worlds with the same rules.

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -1,4 +1,19 @@
+---
+title: Overrides
+nav_order: 7
+description: "Server-wide boost multiplier overrides by world, world group, and WorldGuard region"
+---
+
 # Boost Overrides: Worlds, Groups, and Regions
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 EzBoost supports advanced configuration overrides for boosts based on world, world group, and WorldGuard region. This allows you to customize boost behavior for specific worlds or protected regions on your server.
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,4 +1,19 @@
+---
+title: Permissions
+nav_order: 3
+description: "Full permissions reference and default values for EzBoost"
+---
+
 # Permissions
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
 
 This page documents all permissions used by EzBoost, including their purposes, default assignments, and examples.
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -35,36 +35,42 @@ EzBoost uses a hierarchical permission system to control access to different fea
 ## Detailed Descriptions
 
 ### `ezboost.use`
+
 - **Purpose**: Grants access to player-facing boost functionality
 - **Required for**: Opening the boosts GUI, activating boosts via commands
 - **Default**: All players
 - **Note**: This is a base permission that must be combined with specific boost permissions
 
 ### `ezboost.admin`
+
 - **Purpose**: Allows access to administrative features
 - **Required for**: Opening the admin GUI to create/manage boosts
 - **Default**: OPs (server operators)
 - **Note**: This permission is checked for admin commands only
 
 ### `ezboost.reload`
+
 - **Purpose**: Permits reloading of plugin configuration
 - **Required for**: Using `/ezboost reload` command
 - **Default**: OPs
 - **Note**: Useful for administrators who need to reload config without full admin access
 
 ### `ezboost.give`
+
 - **Purpose**: Allows distributing boost tokens
 - **Required for**: Giving boost token items to players
 - **Default**: OPs
 - **Note**: Useful for moderators or shop plugins
 
 ### `ezboost.cooldown.bypass`
+
 - **Purpose**: Ignores cooldown restrictions
 - **Required for**: Activating boosts without waiting for cooldowns
 - **Default**: OPs
 - **Note**: Should be given sparingly to prevent abuse
 
 ### `ezboost.boost.<key>`
+
 - **Purpose**: Controls access to individual boosts
 - **Required for**: Activating specific boosts
 - **Default**: All players
@@ -77,11 +83,13 @@ EzBoost uses a hierarchical permission system to control access to different fea
 ## Permission Combinations
 
 To activate a boost, players need:
+
 - `ezboost.use` (base permission)
 - `ezboost.boost.<key>` (specific boost permission)
 
 Example: To allow a player to use the speed boost:
-```
+
+```text
 ezboost.use
 ezboost.boost.speed
 ```
@@ -89,6 +97,7 @@ ezboost.boost.speed
 ## Permission Management
 
 ### Using LuckPerms (Recommended)
+
 ```bash
 # Grant base permission
 lp user <player> permission set ezboost.use true
@@ -101,6 +110,7 @@ lp user <admin> permission set ezboost.admin true
 ```
 
 ### Using PermissionsEx
+
 ```yaml
 groups:
   default:
@@ -116,6 +126,7 @@ groups:
 ```
 
 ### Using GroupManager
+
 ```yaml
 groups:
   Default:
@@ -142,43 +153,4 @@ groups:
 
 - **GUI not showing boosts**: Check `ezboost.use` and specific `ezboost.boost.<key>` permissions
 - **Command denied**: Verify appropriate admin permissions
-- **Cooldowns not working**: Check `ezboost.cooldown.bypass` for staff</content>
-<parameter name="filePath">/home/niels/gyvex/EzBoost/docs/permissions.md
-# EzBoost Permissions Reference
-
-This document provides a comprehensive overview of all permissions used by EzBoost, including their purpose, default values, and recommended assignment.
-
-## Permission Nodes
-
-| Permission                      | Default   | Description                                                      |
-|----------------------------------|-----------|------------------------------------------------------------------|
-| `ezboost.use`                   | `true`    | Allows players to use boosts and open the boost GUI.             |
-| `ezboost.admin`                 | `op`      | Grants access to all admin commands.                             |
-| `ezboost.reload`                | `op`      | Allows reloading of all configuration and messages.              |
-| `ezboost.give`                  | `op`      | Allows giving boost tokens to players.                           |
-| `ezboost.cooldown.bypass`       | `op`      | Bypasses all boost cooldowns.                                    |
-| `ezboost.boost.<key>`           | `true`    | Grants access to a specific boost (replace `<key>` with boost).  |
-
-## Usage Examples
-
-- Grant all players access to boosts:
-  ```yaml
-  - ezboost.use
-  - ezboost.boost.*
-  ```
-- Restrict a special boost to VIPs:
-  ```yaml
-  - ezboost.boost.vip
-  ```
-- Give staff full admin access:
-  ```yaml
-  - ezboost.admin
-  - ezboost.reload
-  - ezboost.give
-  - ezboost.cooldown.bypass
-  ```
-
-## Notes
-- Per-boost permissions (`ezboost.boost.<key>`) allow fine-grained control over which boosts players can use.
-- Use permission plugins (LuckPerms, PermissionsEx, etc.) to manage group assignments.
-- By default, most permissions are granted to all players except admin actions, which require operator status.
+- **Cooldowns not working**: Check `ezboost.cooldown.bypass` for staff

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,25 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
- docs/_config.yml: Just the Docs remote theme, EzBoost title/description, GitHub Pages URL, aux_links, search, back-to-top, footer, kramdown config
- docs/index.md: new landing page (layout: home) with features overview, quick-start steps, and full documentation table
- .markdownlint.yml: markdownlint configuration matching Jaloquent style
- .github/workflows/docs.yml: deploy Jekyll site to GitHub Pages on release
- .github/workflows/lint.yml: markdownlint validation on docs PR changes
- .github/workflows/coverage.yml: JaCoCo build + Codecov upload on push/PR
- pom.xml: add jacoco-maven-plugin 0.8.12 (prepare-agent + verify report)
- README.md: replace flat-square badges with Jaloquent-style badges; add CI, GitHub Packages, Coverage, and Docs badges; update Documentation section to link to GitHub Pages site
- docs/*.md: add Jekyll front matter (title, nav_order, description) and Just the Docs TOC blocks to all 13 documentation pages