### PR TITLE
feat: add Folia compatibility and Folia smoke test

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   PAPER_261_VERSION: "26.1.2"  # New MC versioning scheme; uses fill.papermc.io API
+  FOLIA_VERSION: "26.1.2"      # Folia tracks the same MC version as Paper
   SPIGOT_VERSION: "1.21.11"
   BUKKIT_VERSION: "1.21.11"
 
@@ -51,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server: [paper, spigot, bukkit]
+        server: [paper, folia, spigot, bukkit]
 
     steps:
       - name: Set up Java 25
@@ -82,6 +83,16 @@ jobs:
             | jq -r 'map(select(.channel == "STABLE")) | first | .downloads["server:default"].url')
           curl -sfLo server.jar "$URL"
           echo "Paper 26.1.2 URL: $URL"
+
+      # ── Folia 26.1.2 (same fill.papermc.io API, project=folia) ───────────
+      - name: Download Folia ${{ env.FOLIA_VERSION }}
+        if: matrix.server == 'folia'
+        run: |
+          URL=$(curl -sf \
+            "https://fill.papermc.io/v3/projects/folia/versions/${FOLIA_VERSION}/builds" \
+            | jq -r 'map(select(.channel == "STABLE")) | first | .downloads["server:default"].url')
+          curl -sfLo server.jar "$URL"
+          echo "Folia 26.1.2 URL: $URL"
 
       # ── Spigot (built via BuildTools; result cached by Spigot version) ─────
       # BuildTools is strict about its build JVM; use Java 21 to compile

--- a/src/main/java/com/skyblockexp/ezboost/FoliaScheduler.java
+++ b/src/main/java/com/skyblockexp/ezboost/FoliaScheduler.java
@@ -1,0 +1,104 @@
+package com.skyblockexp.ezboost;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * Runtime Folia/Paper scheduler adapter.
+ * Use static factory methods instead of direct BukkitScheduler calls so the
+ * plugin works on both threaded-region Folia and standard Paper/Spigot.
+ */
+public final class FoliaScheduler {
+
+    /** {@code true} when the server is running Folia. */
+    public static final boolean FOLIA;
+
+    static {
+        boolean folia;
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            folia = true;
+        } catch (ClassNotFoundException ignored) {
+            folia = false;
+        }
+        FOLIA = folia;
+    }
+
+    private FoliaScheduler() {}
+
+    /**
+     * A cancellable task handle that works on both Paper and Folia.
+     */
+    @FunctionalInterface
+    public interface TaskHandle {
+        void cancel();
+
+        /** A no-op handle for tasks that were never scheduled (e.g. entity retired on Folia). */
+        TaskHandle NOOP = () -> {};
+    }
+
+    /**
+     * Schedules a one-shot entity-bound task after {@code delayTicks} server ticks.
+     * On Folia, the task runs on the entity's owning region thread.
+     * If the entity is retired before the task runs, it is silently dropped.
+     */
+    public static TaskHandle runEntityTaskLater(JavaPlugin plugin, Entity entity, Runnable task, long delayTicks) {
+        if (FOLIA) {
+            var scheduled = entity.getScheduler().runDelayed(
+                    plugin, t -> task.run(), null, Math.max(1L, delayTicks));
+            return scheduled != null ? scheduled::cancel : TaskHandle.NOOP;
+        }
+        BukkitTask bt = plugin.getServer().getScheduler().runTaskLater(plugin, task, delayTicks);
+        return bt::cancel;
+    }
+
+    /**
+     * Schedules a repeating entity-bound task.
+     * On Folia, if the entity is retired the task is silently dropped.
+     */
+    public static TaskHandle runEntityTaskTimer(JavaPlugin plugin, Entity entity, Runnable task,
+                                                long initialDelay, long period) {
+        if (FOLIA) {
+            var scheduled = entity.getScheduler().runAtFixedRate(
+                    plugin, t -> task.run(), null, Math.max(1L, initialDelay), Math.max(1L, period));
+            return scheduled != null ? scheduled::cancel : TaskHandle.NOOP;
+        }
+        BukkitTask bt = plugin.getServer().getScheduler().runTaskTimer(plugin, task, initialDelay, period);
+        return bt::cancel;
+    }
+
+    /**
+     * Schedules an immediate entity-bound task (no delay).
+     * On Folia, runs on the entity's owning region thread.
+     */
+    public static void runEntityTask(JavaPlugin plugin, Entity entity, Runnable task) {
+        if (FOLIA) {
+            entity.getScheduler().run(plugin, t -> task.run(), null);
+            return;
+        }
+        plugin.getServer().getScheduler().runTask(plugin, task);
+    }
+
+    /**
+     * Schedules an asynchronous task.
+     */
+    public static void runAsync(JavaPlugin plugin, Runnable task) {
+        if (FOLIA) {
+            plugin.getServer().getAsyncScheduler().runNow(plugin, t -> task.run());
+            return;
+        }
+        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, task);
+    }
+
+    /**
+     * Schedules a task on the global region (server-level state, console commands).
+     */
+    public static void runGlobal(JavaPlugin plugin, Runnable task) {
+        if (FOLIA) {
+            plugin.getServer().getGlobalRegionScheduler().run(plugin, t -> task.run());
+            return;
+        }
+        plugin.getServer().getScheduler().runTask(plugin, task);
+    }
+}

--- a/src/main/java/com/skyblockexp/ezboost/boost/BoostManager.java
+++ b/src/main/java/com/skyblockexp/ezboost/boost/BoostManager.java
@@ -22,7 +22,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.scheduler.BukkitTask;
+import com.skyblockexp.ezboost.FoliaScheduler;
 
 import java.util.concurrent.ConcurrentMap;
 import java.util.Collections;
@@ -38,8 +38,8 @@ public final class BoostManager {
     private final BoostStorage storage;
     private final Logger logger;
     private final Map<UUID, BoostState> states = new ConcurrentHashMap<>();
-    private final Map<UUID, BukkitTask> expiryTasks = new HashMap<>();
-    private final Map<UUID, BukkitTask> actionbarTasks = new HashMap<>();
+    private final Map<UUID, FoliaScheduler.TaskHandle> expiryTasks = new HashMap<>();
+    private final Map<UUID, FoliaScheduler.TaskHandle> actionbarTasks = new HashMap<>();
     private CurrencyFormatter currencyFormatter;
 
     // Custom effect registry
@@ -549,7 +549,7 @@ public final class BoostManager {
     private void scheduleExpiry(Player player, BoostDefinition boost, long endTimestamp) {
         cancelExpiryTask(player.getUniqueId());
         long delayTicks = Math.max(1L, (endTimestamp - System.currentTimeMillis()) / 50L);
-        BukkitTask task = Bukkit.getScheduler().runTaskLater(plugin, () -> {
+        FoliaScheduler.TaskHandle task = FoliaScheduler.runEntityTaskLater(plugin, player, () -> {
             BoostState state = states.get(player.getUniqueId());
             if (state == null || state.activeBoostKey() == null) {
                 return;
@@ -568,7 +568,7 @@ public final class BoostManager {
             return;
         }
         cancelActionbarTask(player.getUniqueId());
-        BukkitTask task = Bukkit.getScheduler().runTaskTimer(plugin, () -> {
+        FoliaScheduler.TaskHandle task = FoliaScheduler.runEntityTaskTimer(plugin, player, () -> {
             BoostState state = states.get(player.getUniqueId());
             if (state == null || state.activeBoostKey() == null) {
                 cancelActionbarTask(player.getUniqueId());
@@ -585,14 +585,14 @@ public final class BoostManager {
     }
 
     private void cancelExpiryTask(UUID uuid) {
-        BukkitTask task = expiryTasks.remove(uuid);
+        FoliaScheduler.TaskHandle task = expiryTasks.remove(uuid);
         if (task != null) {
             task.cancel();
         }
     }
 
     private void cancelActionbarTask(UUID uuid) {
-        BukkitTask task = actionbarTasks.remove(uuid);
+        FoliaScheduler.TaskHandle task = actionbarTasks.remove(uuid);
         if (task != null) {
             task.cancel();
         }
@@ -672,7 +672,11 @@ public final class BoostManager {
                     .replace("{player}", player.getName())
                       .replace("{displayname}", player.getName())
                     .replace("{boost}", boost.key());
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), parsed);
+            if (FoliaScheduler.FOLIA) {
+                FoliaScheduler.runGlobal(plugin, () -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), parsed));
+            } else {
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), parsed);
+            }
         }
     }
 

--- a/src/main/java/com/skyblockexp/ezboost/gui/AdminBoostCreationGui.java
+++ b/src/main/java/com/skyblockexp/ezboost/gui/AdminBoostCreationGui.java
@@ -1,5 +1,6 @@
 package com.skyblockexp.ezboost.gui;
 
+import com.skyblockexp.ezboost.FoliaScheduler;
 import com.skyblockexp.ezboost.boost.BoostManager;
 import com.skyblockexp.ezboost.config.Messages;
 import com.skyblockexp.ezboost.gui.admin.*;
@@ -13,7 +14,9 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Main controller for the admin boost creation GUI.
@@ -33,8 +36,9 @@ public class AdminBoostCreationGui {
             .build();
     private final NamespacedKey actionKey;
     private final Map<UUID, BoostCreationState> states = new HashMap<>();
-    private final Map<UUID, String> inputModes = new HashMap<>(); // player -> field
-    private final Map<UUID, java.util.function.Consumer<String>> inputCallbacks = new HashMap<>();
+    private final Map<UUID, String> inputModes = new ConcurrentHashMap<>();
+    private final Map<UUID, java.util.function.Consumer<String>> inputCallbacks = new ConcurrentHashMap<>();
+    private final Set<UUID> chatInputWaiters = ConcurrentHashMap.newKeySet();
     private final File adminStatesFile;
 
     // Component classes
@@ -60,9 +64,11 @@ public class AdminBoostCreationGui {
                                                        UUID uuid = player.getUniqueId();
                                                        inputModes.put(uuid, "input");
                                                        inputCallbacks.put(uuid, callback);
-                                                   });
+                                                   },
+                                                   chatInputWaiters::add);
         this.clickHandler = new AdminGuiClickHandler(plugin, boostManager, messages, legacySerializer,
-                                                   renderer, inputHandler, validator, this::clearSavedState);
+                                                   renderer, inputHandler, validator, this::clearSavedState,
+                                                   chatInputWaiters::add);
     }
 
     /**
@@ -136,14 +142,14 @@ public class AdminBoostCreationGui {
             if ("cancel".equalsIgnoreCase(message)) {
                 player.sendMessage(legacySerializer.serialize(Component.text("§aInput cancelled.")));
                 // Reopen GUI after cancel
-                plugin.getServer().getScheduler().runTask(plugin, () -> {
+                FoliaScheduler.runEntityTask(plugin, player, () -> {
                     player.closeInventory();
                     open(player);
                 });
             } else {
                 callback.accept(message);
                 // Reopen GUI after successful input
-                plugin.getServer().getScheduler().runTask(plugin, () -> {
+                FoliaScheduler.runEntityTask(plugin, player, () -> {
                     player.closeInventory();
                     open(player);
                 });
@@ -156,6 +162,24 @@ public class AdminBoostCreationGui {
      */
     public boolean isPlayerInInputMode(UUID uuid) {
         return inputModes.containsKey(uuid);
+    }
+
+    /**
+     * Returns true if the player is awaiting any type of chat input (standard input mode
+     * or a PDC-based state such as amplifier or custom permission). Thread-safe.
+     */
+    public boolean isPlayerPendingAnyInput(UUID uuid) {
+        return inputModes.containsKey(uuid) || chatInputWaiters.contains(uuid);
+    }
+
+    /** Marks a player as waiting for a PDC-based chat input (thread-safe). */
+    public void markChatWaiter(UUID uuid) {
+        chatInputWaiters.add(uuid);
+    }
+
+    /** Removes the PDC-based chat input mark for a player (thread-safe). */
+    public void unmarkChatWaiter(UUID uuid) {
+        chatInputWaiters.remove(uuid);
     }
 
     /**
@@ -184,6 +208,7 @@ public class AdminBoostCreationGui {
 
     public void handleEffectAmplifierInput(Player player, String input) {
         UUID uuid = player.getUniqueId();
+        unmarkChatWaiter(uuid);
         BoostCreationState state = states.get(uuid);
         if (state != null) {
             inputHandler.handleEffectAmplifierInput(player, input, state);
@@ -216,6 +241,7 @@ public class AdminBoostCreationGui {
 
     public void handleCustomPermissionInput(Player player, String permission) {
         UUID uuid = player.getUniqueId();
+        unmarkChatWaiter(uuid);
         BoostCreationState state = states.get(uuid);
         if (state != null) {
             inputHandler.handleCustomPermissionInput(player, permission, state);

--- a/src/main/java/com/skyblockexp/ezboost/gui/admin/AdminGuiClickHandler.java
+++ b/src/main/java/com/skyblockexp/ezboost/gui/admin/AdminGuiClickHandler.java
@@ -1,5 +1,6 @@
 package com.skyblockexp.ezboost.gui.admin;
 
+import com.skyblockexp.ezboost.FoliaScheduler;
 import com.skyblockexp.ezboost.boost.BoostManager;
 import com.skyblockexp.ezboost.config.Messages;
 import com.skyblockexp.ezboost.gui.*;
@@ -23,11 +24,13 @@ public class AdminGuiClickHandler {
     private final AdminGuiInputHandler inputHandler;
     private final AdminGuiValidator validator;
     private final java.util.function.Consumer<Player> clearSavedStateCallback;
+    private final java.util.function.Consumer<UUID> markChatWaiter;
 
     public AdminGuiClickHandler(JavaPlugin plugin, BoostManager boostManager, Messages messages,
                               LegacyComponentSerializer legacySerializer, AdminGuiRenderer renderer,
                               AdminGuiInputHandler inputHandler, AdminGuiValidator validator,
-                              java.util.function.Consumer<Player> clearSavedStateCallback) {
+                              java.util.function.Consumer<Player> clearSavedStateCallback,
+                              java.util.function.Consumer<UUID> markChatWaiter) {
         this.plugin = plugin;
         this.boostManager = boostManager;
         this.messages = messages;
@@ -36,6 +39,7 @@ public class AdminGuiClickHandler {
         this.inputHandler = inputHandler;
         this.validator = validator;
         this.clearSavedStateCallback = clearSavedStateCallback;
+        this.markChatWaiter = markChatWaiter;
     }
 
     /**
@@ -87,7 +91,7 @@ public class AdminGuiClickHandler {
     private void openEffectSelectionGui(Player player) {
         EffectSelectionGui effectGui = new EffectSelectionGui(plugin, effect -> {
             // Effect addition is now handled in handleEffectAmplifierInput
-        });
+        }, markChatWaiter);
         effectGui.open(player);
     }
 
@@ -126,7 +130,7 @@ public class AdminGuiClickHandler {
             state.setPermission(permission);
             // Close permission GUI and reopen main GUI
             player.closeInventory();
-            plugin.getServer().getScheduler().runTask(plugin, () -> {
+            FoliaScheduler.runEntityTask(plugin, player, () -> {
                 Inventory newInventory = renderer.createInventory();
                 renderer.fillInventory(newInventory, state);
                 player.openInventory(newInventory);
@@ -134,12 +138,12 @@ public class AdminGuiClickHandler {
         }, () -> {
             // Reopen main GUI on back button
             player.closeInventory();
-            plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+            FoliaScheduler.runEntityTaskLater(plugin, player, () -> {
                 Inventory newInventory = renderer.createInventory();
                 renderer.fillInventory(newInventory, state);
                 player.openInventory(newInventory);
             }, 1L);
-        });
+        }, markChatWaiter);
         permissionGui.open(player, currentPermission);
     }
 

--- a/src/main/java/com/skyblockexp/ezboost/gui/admin/AdminGuiInputHandler.java
+++ b/src/main/java/com/skyblockexp/ezboost/gui/admin/AdminGuiInputHandler.java
@@ -1,5 +1,6 @@
 package com.skyblockexp.ezboost.gui.admin;
 
+import com.skyblockexp.ezboost.FoliaScheduler;
 import com.skyblockexp.ezboost.boost.BoostEffect;
 import com.skyblockexp.ezboost.gui.*;
 import net.kyori.adventure.text.Component;
@@ -23,14 +24,17 @@ public class AdminGuiInputHandler {
     private final LegacyComponentSerializer legacySerializer;
     private final AdminGuiRenderer renderer;
     private final java.util.function.BiConsumer<Player, java.util.function.Consumer<String>> inputCallbackRegistrar;
+    private final Consumer<UUID> markChatWaiter;
 
     public AdminGuiInputHandler(JavaPlugin plugin, LegacyComponentSerializer legacySerializer,
                               AdminGuiRenderer renderer,
-                              java.util.function.BiConsumer<Player, java.util.function.Consumer<String>> inputCallbackRegistrar) {
+                              java.util.function.BiConsumer<Player, java.util.function.Consumer<String>> inputCallbackRegistrar,
+                              Consumer<UUID> markChatWaiter) {
         this.plugin = plugin;
         this.legacySerializer = legacySerializer;
         this.renderer = renderer;
         this.inputCallbackRegistrar = inputCallbackRegistrar;
+        this.markChatWaiter = markChatWaiter;
     }
 
     /**
@@ -76,7 +80,7 @@ public class AdminGuiInputHandler {
                 player.sendMessage(legacySerializer.serialize(Component.text("§aGUI Slot set to: §6" + slotDisplay)));
             }
             player.closeInventory();
-            plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+            FoliaScheduler.runEntityTaskLater(plugin, player, () -> {
                 Inventory newInventory = renderer.createInventory();
                 renderer.fillInventory(newInventory, state);
                 player.openInventory(newInventory);
@@ -113,7 +117,7 @@ public class AdminGuiInputHandler {
             state.setPermission(permission);
             // Close permission GUI and reopen main GUI
             player.closeInventory();
-            plugin.getServer().getScheduler().runTask(plugin, () -> {
+            FoliaScheduler.runEntityTask(plugin, player, () -> {
                 Inventory newInventory = renderer.createInventory();
                 renderer.fillInventory(newInventory, state);
                 player.openInventory(newInventory);
@@ -121,12 +125,12 @@ public class AdminGuiInputHandler {
         }, () -> {
             // Reopen main GUI on back button
             player.closeInventory();
-            plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+            FoliaScheduler.runEntityTaskLater(plugin, player, () -> {
                 Inventory newInventory = renderer.createInventory();
                 renderer.fillInventory(newInventory, state);
                 player.openInventory(newInventory);
             }, 1L);
-        });
+        }, markChatWaiter);
         permissionGui.handleClick(player, action);
     }
 
@@ -138,21 +142,19 @@ public class AdminGuiInputHandler {
             state.setPermission(perm);
             // Close permission GUI and reopen main GUI
             player.closeInventory();
-            plugin.getServer().getScheduler().runTask(plugin, () -> {
+            FoliaScheduler.runEntityTask(plugin, player, () -> {
                 Inventory newInventory = renderer.createInventory();
                 renderer.fillInventory(newInventory, state);
                 player.openInventory(newInventory);
             });
         }, () -> {
             // Reopen main GUI on back button
-            plugin.getServer().getScheduler().runTask(plugin, () -> {
-                player.closeInventory();
-                plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
-                    Inventory newInventory = renderer.createInventory();
-                    renderer.fillInventory(newInventory, state);
-                    player.openInventory(newInventory);
-                }, 1L);
-            });
+            player.closeInventory();
+            FoliaScheduler.runEntityTaskLater(plugin, player, () -> {
+                Inventory newInventory = renderer.createInventory();
+                renderer.fillInventory(newInventory, state);
+                player.openInventory(newInventory);
+            }, 1L);
         });
         permissionGui.handleCustomPermissionInput(player, permission);
     }
@@ -174,15 +176,13 @@ public class AdminGuiInputHandler {
             EffectSelectionGui effectGui = new EffectSelectionGui(plugin, effect -> {
                 state.addEffect(effect);
                 player.sendMessage(legacySerializer.serialize(Component.text("§aEffect added successfully!")));
-                plugin.getServer().getScheduler().runTask(plugin, () -> {
-                    player.closeInventory();
-                    plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
-                        Inventory newInventory = renderer.createInventory();
-                        renderer.fillInventory(newInventory, state);
-                        player.openInventory(newInventory);
-                    }, 1L);
-                });
-            });
+                player.closeInventory();
+                FoliaScheduler.runEntityTaskLater(plugin, player, () -> {
+                    Inventory newInventory = renderer.createInventory();
+                    renderer.fillInventory(newInventory, state);
+                    player.openInventory(newInventory);
+                }, 1L);
+            }, markChatWaiter);
             effectGui.open(player, page);
             return;
         }
@@ -192,15 +192,13 @@ public class AdminGuiInputHandler {
             EffectSelectionGui effectGui = new EffectSelectionGui(plugin, effect -> {
                 state.addEffect(effect);
                 player.sendMessage(legacySerializer.serialize(Component.text("§aEffect added successfully!")));
-                plugin.getServer().getScheduler().runTask(plugin, () -> {
-                    player.closeInventory();
-                    plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
-                        Inventory newInventory = renderer.createInventory();
-                        renderer.fillInventory(newInventory, state);
-                        player.openInventory(newInventory);
-                    }, 1L);
-                });
-            });
+                player.closeInventory();
+                FoliaScheduler.runEntityTaskLater(plugin, player, () -> {
+                    Inventory newInventory = renderer.createInventory();
+                    renderer.fillInventory(newInventory, state);
+                    player.openInventory(newInventory);
+                }, 1L);
+            }, markChatWaiter);
             effectGui.handleClick(player, action, null);
         }
     }
@@ -238,7 +236,7 @@ public class AdminGuiInputHandler {
             player.getPersistentDataContainer().remove(new NamespacedKey(plugin, "selected-effect"));
 
             // Reopen the main GUI
-            plugin.getServer().getScheduler().runTask(plugin, () -> {
+            FoliaScheduler.runEntityTask(plugin, player, () -> {
                 player.closeInventory(); // Close any currently open GUI first
                 // Create and open a new inventory instead of trying to fill the closed one
                 Inventory newInventory = renderer.createInventory();
@@ -265,14 +263,12 @@ public class AdminGuiInputHandler {
             MaterialSelectionGui materialGui = new MaterialSelectionGui(plugin, material -> {
                 state.setIcon(material);
                 player.sendMessage(legacySerializer.serialize(Component.text("§aIcon material selected!")));
-                plugin.getServer().getScheduler().runTask(plugin, () -> {
-                    player.closeInventory();
-                    plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
-                        Inventory newInventory = renderer.createInventory();
-                        renderer.fillInventory(newInventory, state);
-                        player.openInventory(newInventory);
-                    }, 1L);
-                });
+                player.closeInventory();
+                FoliaScheduler.runEntityTaskLater(plugin, player, () -> {
+                    Inventory newInventory = renderer.createInventory();
+                    renderer.fillInventory(newInventory, state);
+                    player.openInventory(newInventory);
+                }, 1L);
             });
             materialGui.open(player, page);
             return;
@@ -282,14 +278,12 @@ public class AdminGuiInputHandler {
             MaterialSelectionGui materialGui = new MaterialSelectionGui(plugin, material -> {
                 state.setIcon(material);
                 player.sendMessage(legacySerializer.serialize(Component.text("§aIcon material selected!")));
-                plugin.getServer().getScheduler().runTask(plugin, () -> {
-                    player.closeInventory();
-                    plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
-                        Inventory newInventory = renderer.createInventory();
-                        renderer.fillInventory(newInventory, state);
-                        player.openInventory(newInventory);
-                    }, 1L);
-                });
+                player.closeInventory();
+                FoliaScheduler.runEntityTaskLater(plugin, player, () -> {
+                    Inventory newInventory = renderer.createInventory();
+                    renderer.fillInventory(newInventory, state);
+                    player.openInventory(newInventory);
+                }, 1L);
             });
             materialGui.handleClick(player, action, page);
         }

--- a/src/main/java/com/skyblockexp/ezboost/gui/admin/EffectSelectionGui.java
+++ b/src/main/java/com/skyblockexp/ezboost/gui/admin/EffectSelectionGui.java
@@ -30,6 +30,7 @@ public class EffectSelectionGui {
     private final NamespacedKey effectKey;
     private final NamespacedKey pageKey;
     private final Consumer<BoostEffect> onEffectSelected;
+    private final Consumer<UUID> onChatInputStart;
 
     // Common potion effects (lookup by name for version compatibility)
     private static final List<PotionEffectType> COMMON_EFFECTS = new ArrayList<>();
@@ -55,8 +56,13 @@ public class EffectSelectionGui {
     }
 
     public EffectSelectionGui(JavaPlugin plugin, Consumer<BoostEffect> onEffectSelected) {
+        this(plugin, onEffectSelected, uuid -> {});
+    }
+
+    public EffectSelectionGui(JavaPlugin plugin, Consumer<BoostEffect> onEffectSelected, Consumer<UUID> onChatInputStart) {
         this.plugin = plugin;
         this.onEffectSelected = onEffectSelected;
+        this.onChatInputStart = onChatInputStart;
         this.effectKey = new NamespacedKey(plugin, "effect-type");
         this.pageKey = new NamespacedKey(plugin, "page");
     }
@@ -230,10 +236,10 @@ public class EffectSelectionGui {
     }
 
     private void promptForAmplifier(Player player, PotionEffectType effectType) {
+        onChatInputStart.accept(player.getUniqueId());
         player.closeInventory();
         player.sendMessage(legacySerializer.serialize(Component.text("Selected effect: " + formatEffectName(effectType.key().value()))));
-        player.sendMessage(legacySerializer.serialize(Component.text("Enter amplifier level (0-255, 0 = level 1):")))
-;
+        player.sendMessage(legacySerializer.serialize(Component.text("Enter amplifier level (0-255, 0 = level 1):")));
         // Store the effect type for later use
         player.getPersistentDataContainer().set(
             new NamespacedKey(plugin, "selected-effect"),

--- a/src/main/java/com/skyblockexp/ezboost/gui/admin/PermissionInputGui.java
+++ b/src/main/java/com/skyblockexp/ezboost/gui/admin/PermissionInputGui.java
@@ -13,6 +13,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.UUID;
 import java.util.function.Consumer;
 
 public class PermissionInputGui {
@@ -24,6 +25,7 @@ public class PermissionInputGui {
     private final NamespacedKey actionKey;
     private final Consumer<String> onPermissionSelected;
     private final Runnable onBackPressed;
+    private final Consumer<UUID> onChatInputStart;
 
     // GUI Constants
     private static final int INVENTORY_SIZE = 27;
@@ -52,9 +54,14 @@ public class PermissionInputGui {
     };
 
     public PermissionInputGui(JavaPlugin plugin, Consumer<String> onPermissionSelected, Runnable onBackPressed) {
+        this(plugin, onPermissionSelected, onBackPressed, uuid -> {});
+    }
+
+    public PermissionInputGui(JavaPlugin plugin, Consumer<String> onPermissionSelected, Runnable onBackPressed, Consumer<UUID> onChatInputStart) {
         this.plugin = plugin;
         this.onPermissionSelected = onPermissionSelected;
         this.onBackPressed = onBackPressed;
+        this.onChatInputStart = onChatInputStart;
         this.actionKey = new NamespacedKey(plugin, "permission-action");
     }
 
@@ -208,6 +215,7 @@ public class PermissionInputGui {
             open(player, null);
         } else if (ACTION_CUSTOM.equals(action)) {
             // Prompt for custom permission via chat
+            onChatInputStart.accept(player.getUniqueId());
             player.closeInventory();
             player.sendMessage(legacySerializer.serialize(Component.text("§eEnter custom permission in chat:")));
             player.getPersistentDataContainer().set(

--- a/src/main/java/com/skyblockexp/ezboost/listener/AdminGuiChatListener.java
+++ b/src/main/java/com/skyblockexp/ezboost/listener/AdminGuiChatListener.java
@@ -1,5 +1,6 @@
 package com.skyblockexp.ezboost.listener;
 
+import com.skyblockexp.ezboost.FoliaScheduler;
 import com.skyblockexp.ezboost.gui.AdminBoostCreationGui;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
@@ -23,14 +24,30 @@ public class AdminGuiChatListener implements Listener {
     @EventHandler
     public void onPlayerChat(AsyncChatEvent event) {
         Player player = event.getPlayer();
-        String message = PlainTextComponentSerializer.plainText().serialize(event.message());
+        // Use thread-safe check before touching any entity state
+        if (!adminGui.isPlayerPendingAnyInput(player.getUniqueId())) {
+            return;
+        }
+        event.setCancelled(true);
+        final String message = PlainTextComponentSerializer.plainText().serialize(event.message());
+        if (FoliaScheduler.FOLIA) {
+            // On Folia, PDC must be accessed on the entity's region thread
+            player.getScheduler().run(plugin, t -> processInput(player, message), null);
+        } else {
+            processInput(player, message);
+        }
+    }
 
-        // Check for custom permission input
+    /**
+     * Processes the chat input for admin GUI interaction.
+     * Must be called from the entity region thread on Folia (main thread on Paper).
+     */
+    private void processInput(Player player, String message) {
+        // Check for custom permission input (PDC access safe here)
         if (player.getPersistentDataContainer().has(
             new NamespacedKey(plugin, "custom-permission-input"),
             PersistentDataType.STRING
         )) {
-            event.setCancelled(true);
             adminGui.handleCustomPermissionInput(player, message);
             return;
         }
@@ -38,17 +55,13 @@ public class AdminGuiChatListener implements Listener {
         // Check if player has a selected effect (waiting for amplifier input)
         NamespacedKey selectedEffectKey = new NamespacedKey(plugin, "selected-effect");
         String selectedEffect = player.getPersistentDataContainer().get(selectedEffectKey, PersistentDataType.STRING);
-
         if (selectedEffect != null) {
-            // Player is entering amplifier for effect selection
-            event.setCancelled(true);
             adminGui.handleEffectAmplifierInput(player, message);
             return;
         }
 
-        // Check if player is in input mode for regular boost creation
+        // Check regular text input mode
         if (adminGui.isPlayerInInputMode(player.getUniqueId())) {
-            event.setCancelled(true);
             adminGui.handleChatInput(player, message);
         }
     }

--- a/src/main/java/com/skyblockexp/ezboost/update/SpigotUpdateChecker.java
+++ b/src/main/java/com/skyblockexp/ezboost/update/SpigotUpdateChecker.java
@@ -1,5 +1,6 @@
 package com.skyblockexp.ezboost.update;
 
+import com.skyblockexp.ezboost.FoliaScheduler;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
@@ -18,7 +19,7 @@ public final class SpigotUpdateChecker {
     }
 
     public void checkForUpdates() {
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+        FoliaScheduler.runAsync(plugin, () -> {
             try {
                 String latestVersion = fetchLatestVersion();
                 if (latestVersion == null || latestVersion.isBlank()) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: EzBoost
 version: ${project.version}
 main: com.skyblockexp.ezboost.EzBoostPlugin
 api-version: '26.1.2'
+folia-supported: true
 softdepend: [Vault, EzEconomy, WorldGuard, EzShops]
 author: SkyblockExperience
 commands:


### PR DESCRIPTION
- Add FoliaScheduler.java: runtime Folia detection + unified scheduling adapter with TaskHandle interface (entity, async, global region tasks)
- BoostManager: replace BukkitTask maps with TaskHandle; wrap console commands in runGlobal on Folia
- SpigotUpdateChecker: use FoliaScheduler.runAsync
- AdminGuiChatListener: entity-region scheduling on Folia; thread-safe PDC access via isPlayerPendingAnyInput() pre-check
- AdminBoostCreationGui: ConcurrentHashMap for input maps; chatInputWaiters set; isPlayerPendingAnyInput / markChatWaiter / unmarkChatWaiter API
- AdminGuiInputHandler / AdminGuiClickHandler: runEntityTask/Later + wire markChatWaiter into EffectSelectionGui and PermissionInputGui
- EffectSelectionGui / PermissionInputGui: onChatInputStart callback to track PDC-based input states thread-safely
- plugin.yml: add folia-supported: true
- smoke-test.yml: add FOLIA_VERSION env var, folia matrix entry, and Folia download step via fill.papermc.io API